### PR TITLE
Setup for conditional based viewing

### DIFF
--- a/integration_tests/e2e/caseNotesPage.cy.ts
+++ b/integration_tests/e2e/caseNotesPage.cy.ts
@@ -18,7 +18,7 @@ context('Case Notes Page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser', { activeCaseLoadId: 'MDI' })
     cy.task('stubGetCaseNoteTypes')
-    cy.task('stubGetUserCaseLoad')
+    cy.task('stubUserCaseLoads')
   })
 
   context('Case Notes List', () => {
@@ -156,7 +156,7 @@ context('Case Notes Page Not Found', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser', { activeCaseLoadId: 'ZZZ' })
     cy.task('stubGetCaseNoteTypes')
-    cy.task('stubGetUserCaseLoad')
+    cy.task('stubUserCaseLoads')
   })
 
   context('Page Not Found', () => {

--- a/integration_tests/e2e/personalPage.cy.ts
+++ b/integration_tests/e2e/personalPage.cy.ts
@@ -9,248 +9,280 @@ const visitPersonalDetailsPage = (): PersonalPage => {
 }
 
 context('When signed in', () => {
-  beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
-    cy.task('stubInmateDetail', 1102484)
-    cy.task('stubPrisonerDetail', 'G6123VU')
-    cy.task('stubSecondaryLanguages', 1102484)
-    cy.task('stubProperty', 1102484)
-    cy.task('stubAddresses', 'G6123VU')
-    cy.task('stubOffenderContacts', 'G6123VU')
-    cy.task('stubPersonAddresses')
-    cy.task('stubImages')
-    cy.task('stubHealthReferenceDomain')
-    cy.task('stubHealthTreatmentReferenceDomain')
-    cy.task('stubReasonableAdjustments', 1102484)
-    cy.task('stubPersonalCareNeeds', 1102484)
-  })
-
-  it('displays the personal details page', () => {
-    visitPersonalDetailsPage()
-    cy.request('/prisoner/G6123VU/personal').its('body').should('contain', 'Personal')
-  })
-
-  context('Personal details card', () => {
-    it('Displays all the information from the API', () => {
-      const page = visitPersonalDetailsPage()
-      page.personalDetails().fullName().should('have.text', 'John Middle Names Saunders')
-      page.personalDetails().aliases().row(1).name().should('have.text', 'Master Cordian')
-      page.personalDetails().aliases().row(1).dateOfBirth().should('have.text', '1990-08-15')
-      page.personalDetails().aliases().row(2).name().should('have.text', 'Master J117 Chief')
-      page.personalDetails().aliases().row(2).dateOfBirth().should('have.text', '1983-06-17')
-      page.personalDetails().preferredName().should('have.text', 'Working Name')
-      page.personalDetails().dateOfBirth().should('include.text', '1990-10-12')
-      const expectedAge = yearsBetweenDateStrings(new Date('1990-10-12').toISOString(), new Date().toISOString())
-      page.personalDetails().dateOfBirth().should('include.text', `${expectedAge} years old`)
-      page.personalDetails().nationality().should('have.text', 'Stateless')
-      page.personalDetails().otherNationalities().should('have.text', 'multiple nationalities field')
-      page.personalDetails().ethnicGroup().should('have.text', 'White: Eng./Welsh/Scot./N.Irish/British')
-      page.personalDetails().religionOrBelief().should('have.text', 'Celestial Church of God')
-      page.personalDetails().sex().should('have.text', 'Male')
-      page.personalDetails().sexualOrientation().should('have.text', 'Heterosexual / Straight')
-      page.personalDetails().marriageOrCivilPartnership().should('have.text', 'No')
-      page.personalDetails().numberOfChildren().should('have.text', '2')
-      page.personalDetails().typeOfDiet().should('have.text', 'Voluntary - Pork Free/Fish Free')
-      page.personalDetails().smokeOrVaper().should('have.text', 'No')
-      page.personalDetails().domesticAbusePerpetrator().should('have.text', 'Not stated')
-      page.personalDetails().domesticAbuseVictim().should('have.text', 'Not stated')
-      page.personalDetails().socialCareNeeded().should('have.text', 'No')
+  context('As a global search user who does not have the prisoner in their case loads', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.setupUserAuth({
+        roles: ['GLOBAL_SEARCH'],
+        caseLoads: [{ caseloadFunction: '', caseLoadId: '123', currentlyActive: true, description: '', type: '' }],
+      })
+      cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
+      cy.task('stubInmateDetail', 1102484)
+      cy.task('stubPrisonerDetail', 'G6123VU')
+      cy.task('stubSecondaryLanguages', 1102484)
+      cy.task('stubProperty', 1102484)
+      cy.task('stubAddresses', 'G6123VU')
+      cy.task('stubOffenderContacts', 'G6123VU')
+      cy.task('stubPersonAddresses')
+      cy.task('stubImages')
+      cy.task('stubHealthReferenceDomain')
+      cy.task('stubHealthTreatmentReferenceDomain')
+      cy.task('stubReasonableAdjustments', 1102484)
+      cy.task('stubPersonalCareNeeds', 1102484)
     })
 
-    it('Displays all the information from the API: Languages', () => {
-      const page = visitPersonalDetailsPage()
-      page.personalDetails().languages().spoken().should('include.text', 'Welsh')
-      page.personalDetails().languages().written().should('include.text', 'English').and('include.text', '(written)')
-      page.personalDetails().languages().otherLanguages('AZE').language().should('have.text', 'Azerbaijani')
-      page.personalDetails().languages().otherLanguages('BSL').language().should('have.text', 'British Sign Language')
-      page
-        .personalDetails()
-        .languages()
-        .otherLanguages('BSL')
-        .proficiency()
-        .should('include.text', 'reads and speaks only')
-      page
-        .personalDetails()
-        .languages()
-        .otherLanguages('GLA')
-        .language()
-        .should('include.text', 'Gaelic; Scottish Gaelic')
-      page
-        .personalDetails()
-        .languages()
-        .otherLanguages('GLA')
-        .proficiency()
-        .should('include.text', 'writes and speaks only')
-      page.personalDetails().languages().otherLanguages('MAN').language().should('include.text', 'Mandarin')
-      page.personalDetails().languages().otherLanguages('URD').language().should('include.text', 'Urdu')
-      page.personalDetails().languages().otherLanguages('URD').proficiency().should('include.text', 'reads only')
+    it('loads the page with the global search view', () => {
+      // TODO: Update this test once we know the correct criteria
+      visitPersonalDetailsPage()
+      cy.getDataQa('hidden-appearance').should('exist')
     })
   })
 
-  context('Identity numbers card', () => {
-    it('Displays the information from the API', () => {
-      const page = visitPersonalDetailsPage()
-      page.identityNumbers().prisonNumber().should('include.text', 'G6123VU')
-      page.identityNumbers().pncNumber().should('include.text', '08/359381C')
-      page.identityNumbers().croNumber().should('include.text', '400862/08W')
-      page.identityNumbers().homeOfficeReferenceNumber().should('include.text', 'A1234567')
-      page.identityNumbers().nationalInsuranceNumber().should('include.text', 'AB123456A')
-      page.identityNumbers().drivingLicenceNumber().should('include.text', 'ABCD/123456/AB9DE')
+  context('As a user belonging to the prisoners case load', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.task('stubAuthUser')
+      cy.task('stubUserCaseLoads')
+      cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
+      cy.task('stubInmateDetail', 1102484)
+      cy.task('stubPrisonerDetail', 'G6123VU')
+      cy.task('stubSecondaryLanguages', 1102484)
+      cy.task('stubProperty', 1102484)
+      cy.task('stubAddresses', 'G6123VU')
+      cy.task('stubOffenderContacts', 'G6123VU')
+      cy.task('stubPersonAddresses')
+      cy.task('stubImages')
+      cy.task('stubHealthReferenceDomain')
+      cy.task('stubHealthTreatmentReferenceDomain')
+      cy.task('stubReasonableAdjustments', 1102484)
+      cy.task('stubPersonalCareNeeds', 1102484)
     })
-  })
 
-  context('Property card', () => {
-    it('Displays the prisoners property', () => {
-      const page = visitPersonalDetailsPage()
-      page.property().item(0).containerType().should('include.text', 'Valuables')
-      page.property().item(0).sealMark().should('include.text', 'MDA646165646')
-      page.property().item(0).location().should('include.text', 'Property Box 14')
-      page.property().item(1).containerType().should('include.text', 'Confiscated')
-      page.property().item(1).sealMark().should('include.text', '')
-      page.property().item(1).location().should('include.text', 'Property Box 15')
-      page.property().item(2).containerType().should('include.text', 'Branston Storage')
-      page.property().item(2).sealMark().should('include.text', 'BOB')
-      page.property().item(2).location().should('include.text', 'Property Box 3')
+    it('displays the personal details page', () => {
+      visitPersonalDetailsPage()
+      cy.request('/prisoner/G6123VU/personal').its('body').should('contain', 'Personal')
     })
-  })
 
-  context('Addresses', () => {
-    it('Displays the prisoners address', () => {
-      const page = visitPersonalDetailsPage()
-      page.addresess().address().should('include.text', 'Flat 7, premises address, street field')
-      page.addresess().address().should('include.text', 'Leeds')
-      page.addresess().address().should('include.text', 'LS1 AAA')
-      page.addresess().address().should('include.text', 'England')
+    context('Personal details card', () => {
+      it('Displays all the information from the API', () => {
+        const page = visitPersonalDetailsPage()
+        page.personalDetails().fullName().should('have.text', 'John Middle Names Saunders')
+        page.personalDetails().aliases().row(1).name().should('have.text', 'Master Cordian')
+        page.personalDetails().aliases().row(1).dateOfBirth().should('have.text', '1990-08-15')
+        page.personalDetails().aliases().row(2).name().should('have.text', 'Master J117 Chief')
+        page.personalDetails().aliases().row(2).dateOfBirth().should('have.text', '1983-06-17')
+        page.personalDetails().preferredName().should('have.text', 'Working Name')
+        page.personalDetails().dateOfBirth().should('include.text', '1990-10-12')
+        const expectedAge = yearsBetweenDateStrings(new Date('1990-10-12').toISOString(), new Date().toISOString())
+        page.personalDetails().dateOfBirth().should('include.text', `${expectedAge} years old`)
+        page.personalDetails().nationality().should('have.text', 'Stateless')
+        page.personalDetails().otherNationalities().should('have.text', 'multiple nationalities field')
+        page.personalDetails().ethnicGroup().should('have.text', 'White: Eng./Welsh/Scot./N.Irish/British')
+        page.personalDetails().religionOrBelief().should('have.text', 'Celestial Church of God')
+        page.personalDetails().sex().should('have.text', 'Male')
+        page.personalDetails().sexualOrientation().should('have.text', 'Heterosexual / Straight')
+        page.personalDetails().marriageOrCivilPartnership().should('have.text', 'No')
+        page.personalDetails().numberOfChildren().should('have.text', '2')
+        page.personalDetails().typeOfDiet().should('have.text', 'Voluntary - Pork Free/Fish Free')
+        page.personalDetails().smokeOrVaper().should('have.text', 'No')
+        page.personalDetails().domesticAbusePerpetrator().should('have.text', 'Not stated')
+        page.personalDetails().domesticAbuseVictim().should('have.text', 'Not stated')
+        page.personalDetails().socialCareNeeded().should('have.text', 'No')
+      })
 
-      page.addresess().addressTypes().should('include.text', 'Discharge - Permanent Housing')
-      page.addresess().addressTypes().should('include.text', 'HDC Address')
-      page.addresess().addressTypes().should('include.text', 'Other')
-
-      page.addresess().phoneNumbers().should('include.text', '4444555566')
-      page.addresess().phoneNumbers().should('include.text', '0113444444')
-      page.addresess().phoneNumbers().should('include.text', '0113 333444')
-      page.addresess().phoneNumbers().should('include.text', '0800 222333')
-
-      page.addresess().comments().should('include.text', mockAddresses[0].comment)
-      page.addresess().addedOn().should('include.text', '1 May 2020')
+      it('Displays all the information from the API: Languages', () => {
+        const page = visitPersonalDetailsPage()
+        page.personalDetails().languages().spoken().should('include.text', 'Welsh')
+        page.personalDetails().languages().written().should('include.text', 'English').and('include.text', '(written)')
+        page.personalDetails().languages().otherLanguages('AZE').language().should('have.text', 'Azerbaijani')
+        page.personalDetails().languages().otherLanguages('BSL').language().should('have.text', 'British Sign Language')
+        page
+          .personalDetails()
+          .languages()
+          .otherLanguages('BSL')
+          .proficiency()
+          .should('include.text', 'reads and speaks only')
+        page
+          .personalDetails()
+          .languages()
+          .otherLanguages('GLA')
+          .language()
+          .should('include.text', 'Gaelic; Scottish Gaelic')
+        page
+          .personalDetails()
+          .languages()
+          .otherLanguages('GLA')
+          .proficiency()
+          .should('include.text', 'writes and speaks only')
+        page.personalDetails().languages().otherLanguages('MAN').language().should('include.text', 'Mandarin')
+        page.personalDetails().languages().otherLanguages('URD').language().should('include.text', 'Urdu')
+        page.personalDetails().languages().otherLanguages('URD').proficiency().should('include.text', 'reads only')
+      })
     })
-  })
 
-  context('Emergency contacts and next of kin', () => {
-    it('Displays the contacts', () => {
-      const page = visitPersonalDetailsPage()
-
-      const addressShouldIncludeCorrectText = contact => {
-        contact.address().should('include.text', 'Flat 7, premises address, street field')
-        contact.address().should('include.text', 'Leeds')
-        contact.address().should('include.text', 'LS1 AAA')
-        contact.address().should('include.text', 'England')
-
-        contact.addressTypes().should('include.text', 'Discharge - Permanent Housing')
-        contact.addressTypes().should('include.text', 'HDC Address')
-        contact.addressTypes().should('include.text', 'Other')
-
-        contact.addressPhones().should('include.text', '4444555566')
-        contact.addressPhones().should('include.text', '0113444444')
-        contact.addressPhones().should('include.text', '0113 333444')
-        contact.addressPhones().should('include.text', '0800 222333')
-      }
-
-      const firstContact = page.contacts().contact(0)
-      addressShouldIncludeCorrectText(firstContact)
-      firstContact.name().should('include.text', 'First Name Middle Name Surname')
-      firstContact.emergencyContact().should('be.visible')
-      firstContact.relationship().should('include.text', 'Grandson')
-      firstContact.emails().should('include.text', 'Not entered')
-
-      const secondContact = page.contacts().contact(1)
-      addressShouldIncludeCorrectText(secondContact)
-      secondContact.name().should('include.text', 'First Name Middle Name Bob')
-      secondContact.emergencyContact().should('be.visible')
-      secondContact.relationship().should('include.text', 'Cousin')
-      secondContact.emails().should('include.text', 'Not entered')
-      secondContact.phones().should('include.text', '555555 6666666')
-
-      const thirdContact = page.contacts().contact(2)
-      addressShouldIncludeCorrectText(thirdContact)
-      thirdContact.name().should('include.text', 'Dom Bull')
-      thirdContact.relationship().should('include.text', 'Grandfather')
-      thirdContact.emails().should('include.text', 'email@addressgoeshere.com')
-      thirdContact.emails().should('include.text', 'email2@address.com')
-      thirdContact.phones().should('include.text', '0113222333')
-      thirdContact.phones().should('include.text', '0113333444')
-      thirdContact.phones().should('include.text', '07711333444')
+    context('Identity numbers card', () => {
+      it('Displays the information from the API', () => {
+        const page = visitPersonalDetailsPage()
+        page.identityNumbers().prisonNumber().should('include.text', 'G6123VU')
+        page.identityNumbers().pncNumber().should('include.text', '08/359381C')
+        page.identityNumbers().croNumber().should('include.text', '400862/08W')
+        page.identityNumbers().homeOfficeReferenceNumber().should('include.text', 'A1234567')
+        page.identityNumbers().nationalInsuranceNumber().should('include.text', 'AB123456A')
+        page.identityNumbers().drivingLicenceNumber().should('include.text', 'ABCD/123456/AB9DE')
+      })
     })
-  })
 
-  context('Appearance', () => {
-    it('Displays the appearance information', () => {
-      const page = visitPersonalDetailsPage()
-      page.appearance().height().should('include.text', '1.88m')
-      page.appearance().weight().should('include.text', '86kg')
-      page.appearance().hairColour().should('include.text', 'Brown')
-      page.appearance().leftEyeColour().should('include.text', 'Blue')
-      page.appearance().rightEyeColour().should('include.text', 'Blue')
-      page.appearance().shapeOfFace().should('include.text', 'Angular')
-      page.appearance().build().should('include.text', 'Proportional')
-      page.appearance().shoeSize().should('include.text', '10')
-      page.appearance().warnedAboutTattooing().should('include.text', 'Yes')
-      page.appearance().warnedNotTochangeAppearance().should('include.text', 'Yes')
-
-      page.appearance().distinguishingMarks(0).type().should('include.text', 'Tattoo')
-      page.appearance().distinguishingMarks(0).side().should('include.text', 'Left')
-      page.appearance().distinguishingMarks(0).comment().should('include.text', 'Red bull Logo')
-      page.appearance().distinguishingMarks(0).image().should('have.attr', 'src').and('include', '1413021')
-
-      page.appearance().distinguishingMarks(1).type().should('include.text', 'Tattoo')
-      page.appearance().distinguishingMarks(1).side().should('include.text', 'Front')
-      page.appearance().distinguishingMarks(1).comment().should('include.text', 'ARC reactor image')
-      page.appearance().distinguishingMarks(1).image().should('have.attr', 'src').and('include', '1413020')
-
-      page.appearance().distinguishingMarks(2).type().should('include.text', 'Tattoo')
-      page.appearance().distinguishingMarks(2).side().should('include.text', 'Right')
-      page.appearance().distinguishingMarks(2).comment().should('include.text', 'Monster drink logo')
-      page.appearance().distinguishingMarks(2).orientation().should('include.text', 'Facing')
-      page.appearance().distinguishingMarks(2).image().should('have.attr', 'src').and('include', '1413022')
+    context('Property card', () => {
+      it('Displays the prisoners property', () => {
+        const page = visitPersonalDetailsPage()
+        page.property().item(0).containerType().should('include.text', 'Valuables')
+        page.property().item(0).sealMark().should('include.text', 'MDA646165646')
+        page.property().item(0).location().should('include.text', 'Property Box 14')
+        page.property().item(1).containerType().should('include.text', 'Confiscated')
+        page.property().item(1).sealMark().should('include.text', '')
+        page.property().item(1).location().should('include.text', 'Property Box 15')
+        page.property().item(2).containerType().should('include.text', 'Branston Storage')
+        page.property().item(2).sealMark().should('include.text', 'BOB')
+        page.property().item(2).location().should('include.text', 'Property Box 3')
+      })
     })
-  })
 
-  context('Security', () => {
-    it('Displays the security warnings', () => {
-      const page = visitPersonalDetailsPage()
-      page.security().interestToImmigration().should('be.visible')
-      page.security().travelRestrictions().should('be.visible')
-      page.security().travelRestrictions().should('include.text', 'some travel restrictions')
+    context('Addresses', () => {
+      it('Displays the prisoners address', () => {
+        const page = visitPersonalDetailsPage()
+        page.addresess().address().should('include.text', 'Flat 7, premises address, street field')
+        page.addresess().address().should('include.text', 'Leeds')
+        page.addresess().address().should('include.text', 'LS1 AAA')
+        page.addresess().address().should('include.text', 'England')
+
+        page.addresess().addressTypes().should('include.text', 'Discharge - Permanent Housing')
+        page.addresess().addressTypes().should('include.text', 'HDC Address')
+        page.addresess().addressTypes().should('include.text', 'Other')
+
+        page.addresess().phoneNumbers().should('include.text', '4444555566')
+        page.addresess().phoneNumbers().should('include.text', '0113444444')
+        page.addresess().phoneNumbers().should('include.text', '0113 333444')
+        page.addresess().phoneNumbers().should('include.text', '0800 222333')
+
+        page.addresess().comments().should('include.text', mockAddresses[0].comment)
+        page.addresess().addedOn().should('include.text', '1 May 2020')
+      })
     })
-  })
 
-  context('Care needs', () => {
-    it('Displays the care needs', () => {
-      const page = visitPersonalDetailsPage()
-      page.careNeeds().personalCareNeeds(0).type().should('include.text', 'Maternity Status')
-      page.careNeeds().personalCareNeeds(0).description().should('include.text', 'Preg, acc under 9mths')
-      page.careNeeds().personalCareNeeds(0).comment().should('include.text', 'a comment')
-      page.careNeeds().personalCareNeeds(0).addedOn().should('include.text', '21 June 2010')
+    context('Emergency contacts and next of kin', () => {
+      it('Displays the contacts', () => {
+        const page = visitPersonalDetailsPage()
 
-      page
-        .careNeeds()
-        .reasonableAdjustments(0)
-        .description()
-        .should('include.text', 'Behavioural responses/Body language')
-      page
-        .careNeeds()
-        .reasonableAdjustments(0)
-        .comment()
-        .should('include.text', 'psych care type adjustment comment goes here')
-      page.careNeeds().reasonableAdjustments(0).addedOn().should('include.text', '9 June 1999')
-      page.careNeeds().reasonableAdjustments(0).addedOn().should('include.text', 'Moorland (HMP & YOI)')
+        const addressShouldIncludeCorrectText = contact => {
+          contact.address().should('include.text', 'Flat 7, premises address, street field')
+          contact.address().should('include.text', 'Leeds')
+          contact.address().should('include.text', 'LS1 AAA')
+          contact.address().should('include.text', 'England')
 
-      page.careNeeds().reasonableAdjustments(1).description().should('include.text', 'Comfort and Dressing Aids')
-      page.careNeeds().reasonableAdjustments(1).addedOn().should('include.text', '9 June 2020')
-      page.careNeeds().reasonableAdjustments(1).addedOn().should('include.text', 'Moorland (HMP & YOI)')
+          contact.addressTypes().should('include.text', 'Discharge - Permanent Housing')
+          contact.addressTypes().should('include.text', 'HDC Address')
+          contact.addressTypes().should('include.text', 'Other')
+
+          contact.addressPhones().should('include.text', '4444555566')
+          contact.addressPhones().should('include.text', '0113444444')
+          contact.addressPhones().should('include.text', '0113 333444')
+          contact.addressPhones().should('include.text', '0800 222333')
+        }
+
+        const firstContact = page.contacts().contact(0)
+        addressShouldIncludeCorrectText(firstContact)
+        firstContact.name().should('include.text', 'First Name Middle Name Surname')
+        firstContact.emergencyContact().should('be.visible')
+        firstContact.relationship().should('include.text', 'Grandson')
+        firstContact.emails().should('include.text', 'Not entered')
+
+        const secondContact = page.contacts().contact(1)
+        addressShouldIncludeCorrectText(secondContact)
+        secondContact.name().should('include.text', 'First Name Middle Name Bob')
+        secondContact.emergencyContact().should('be.visible')
+        secondContact.relationship().should('include.text', 'Cousin')
+        secondContact.emails().should('include.text', 'Not entered')
+        secondContact.phones().should('include.text', '555555 6666666')
+
+        const thirdContact = page.contacts().contact(2)
+        addressShouldIncludeCorrectText(thirdContact)
+        thirdContact.name().should('include.text', 'Dom Bull')
+        thirdContact.relationship().should('include.text', 'Grandfather')
+        thirdContact.emails().should('include.text', 'email@addressgoeshere.com')
+        thirdContact.emails().should('include.text', 'email2@address.com')
+        thirdContact.phones().should('include.text', '0113222333')
+        thirdContact.phones().should('include.text', '0113333444')
+        thirdContact.phones().should('include.text', '07711333444')
+      })
+    })
+
+    context('Appearance', () => {
+      it('Displays the appearance information', () => {
+        const page = visitPersonalDetailsPage()
+        page.appearance().height().should('include.text', '1.88m')
+        page.appearance().weight().should('include.text', '86kg')
+        page.appearance().hairColour().should('include.text', 'Brown')
+        page.appearance().leftEyeColour().should('include.text', 'Blue')
+        page.appearance().rightEyeColour().should('include.text', 'Blue')
+        page.appearance().shapeOfFace().should('include.text', 'Angular')
+        page.appearance().build().should('include.text', 'Proportional')
+        page.appearance().shoeSize().should('include.text', '10')
+        page.appearance().warnedAboutTattooing().should('include.text', 'Yes')
+        page.appearance().warnedNotTochangeAppearance().should('include.text', 'Yes')
+
+        page.appearance().distinguishingMarks(0).type().should('include.text', 'Tattoo')
+        page.appearance().distinguishingMarks(0).side().should('include.text', 'Left')
+        page.appearance().distinguishingMarks(0).comment().should('include.text', 'Red bull Logo')
+        page.appearance().distinguishingMarks(0).image().should('have.attr', 'src').and('include', '1413021')
+
+        page.appearance().distinguishingMarks(1).type().should('include.text', 'Tattoo')
+        page.appearance().distinguishingMarks(1).side().should('include.text', 'Front')
+        page.appearance().distinguishingMarks(1).comment().should('include.text', 'ARC reactor image')
+        page.appearance().distinguishingMarks(1).image().should('have.attr', 'src').and('include', '1413020')
+
+        page.appearance().distinguishingMarks(2).type().should('include.text', 'Tattoo')
+        page.appearance().distinguishingMarks(2).side().should('include.text', 'Right')
+        page.appearance().distinguishingMarks(2).comment().should('include.text', 'Monster drink logo')
+        page.appearance().distinguishingMarks(2).orientation().should('include.text', 'Facing')
+        page.appearance().distinguishingMarks(2).image().should('have.attr', 'src').and('include', '1413022')
+      })
+    })
+
+    context('Security', () => {
+      it('Displays the security warnings', () => {
+        const page = visitPersonalDetailsPage()
+        page.security().interestToImmigration().should('be.visible')
+        page.security().travelRestrictions().should('be.visible')
+        page.security().travelRestrictions().should('include.text', 'some travel restrictions')
+      })
+    })
+
+    context('Care needs', () => {
+      it('Displays the care needs', () => {
+        const page = visitPersonalDetailsPage()
+        page.careNeeds().personalCareNeeds(0).type().should('include.text', 'Maternity Status')
+        page.careNeeds().personalCareNeeds(0).description().should('include.text', 'Preg, acc under 9mths')
+        page.careNeeds().personalCareNeeds(0).comment().should('include.text', 'a comment')
+        page.careNeeds().personalCareNeeds(0).addedOn().should('include.text', '21 June 2010')
+
+        page
+          .careNeeds()
+          .reasonableAdjustments(0)
+          .description()
+          .should('include.text', 'Behavioural responses/Body language')
+        page
+          .careNeeds()
+          .reasonableAdjustments(0)
+          .comment()
+          .should('include.text', 'psych care type adjustment comment goes here')
+        page.careNeeds().reasonableAdjustments(0).addedOn().should('include.text', '9 June 1999')
+        page.careNeeds().reasonableAdjustments(0).addedOn().should('include.text', 'Moorland (HMP & YOI)')
+
+        page.careNeeds().reasonableAdjustments(1).description().should('include.text', 'Comfort and Dressing Aids')
+        page.careNeeds().reasonableAdjustments(1).addedOn().should('include.text', '9 June 2020')
+        page.careNeeds().reasonableAdjustments(1).addedOn().should('include.text', 'Moorland (HMP & YOI)')
+      })
     })
   })
 })

--- a/integration_tests/e2e/personalPage.cy.ts
+++ b/integration_tests/e2e/personalPage.cy.ts
@@ -13,7 +13,7 @@ context('When signed in', () => {
     beforeEach(() => {
       cy.task('reset')
       cy.setupUserAuth({
-        roles: ['GLOBAL_SEARCH'],
+        roles: ['ROLE_GLOBAL_SEARCH'],
         caseLoads: [{ caseloadFunction: '', caseLoadId: '123', currentlyActive: true, description: '', type: '' }],
       })
       cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -13,7 +13,11 @@ declare global {
       setupAlertsPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
       setupWorkAndSkillsPageStubs(options: { prisonerNumber: string; emptyStates: boolean }): Chainable<AUTWindow>
       setupOffencesPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
-      setupUserAuth(options: { roles?: string[]; caseLoads?: CaseLoad[] }): Chainable<AUTWindow>
+      setupUserAuth(options: {
+        roles?: string[]
+        caseLoads?: CaseLoad[]
+        activeCaseLoadId?: string
+      }): Chainable<AUTWindow>
       getDataQa(id: string): Chainable<JQuery<HTMLElement>>
       findDataQa(id: string): Chainable<JQuery<HTMLElement>>
     }

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -1,16 +1,21 @@
-declare namespace Cypress {
-  interface Chainable {
-    /**
-     * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
-     * @example cy.signIn({ failOnStatusCode: boolean })
-     */
-    signIn(options?: { failOnStatusCode?: boolean; redirectPath?: string }): Chainable<AUTWindow>
-    setupBannerStubs(options: { prisonerNumber: string }): Chainable<AUTWindow>
-    setupOverviewPageStubs(options: { prisonerNumber: string; bookingId: string }): Chainable<AUTWindow>
-    setupAlertsPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
-    setupWorkAndSkillsPageStubs(options: { prisonerNumber: string; emptyStates: boolean }): Chainable<AUTWindow>
-    setupOffencesPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
-    getDataQa(id: string): Chainable<JQuery<HTMLElement>>
-    findDataQa(id: string): Chainable<JQuery<HTMLElement>>
+import { CaseLoad } from '../server/interfaces/caseLoad'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Custom command to signIn. Set failOnStatusCode to false if you expect and non 200 return code
+       * @example cy.signIn({ failOnStatusCode: boolean })
+       */
+      signIn(options?: { failOnStatusCode?: boolean; redirectPath?: string }): Chainable<AUTWindow>
+      setupBannerStubs(options: { prisonerNumber: string }): Chainable<AUTWindow>
+      setupOverviewPageStubs(options: { prisonerNumber: string; bookingId: string }): Chainable<AUTWindow>
+      setupAlertsPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
+      setupWorkAndSkillsPageStubs(options: { prisonerNumber: string; emptyStates: boolean }): Chainable<AUTWindow>
+      setupOffencesPageStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
+      setupUserAuth(options: { roles?: string[]; caseLoads?: CaseLoad[] }): Chainable<AUTWindow>
+      getDataQa(id: string): Chainable<JQuery<HTMLElement>>
+      findDataQa(id: string): Chainable<JQuery<HTMLElement>>
+    }
   }
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -153,6 +153,6 @@ export default {
       token(userRoles),
       tokenVerification.stubVerifyToken(),
     ]),
-  stubAuthUser: ({ name = 'john smith', activeCaseLoadId = undefined } = {}): Promise<[Response, Response]> =>
-    Promise.all([stubUser(name, activeCaseLoadId), stubUserRoles()]),
+  stubAuthUser: ({ name = 'john smith', activeCaseLoadId = undefined } = {}): Promise<[Response]> =>
+    Promise.all([stubUser(name, activeCaseLoadId)]),
 }

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -139,21 +139,6 @@ const stubUser = (name: string, activeCaseLoadId?: string) =>
     },
   })
 
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
-    },
-  })
-
 export default {
   getSignInUrl,
   stubAuthPing: ping,

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -35,6 +35,7 @@ import { prisonerSentenceDetailsMock } from '../../server/data/localMockData/pri
 import { caseNoteUsageMock } from '../../server/data/localMockData/caseNoteUsageMock'
 import { caseNoteCountMock } from '../../server/data/localMockData/caseNoteCountMock'
 import { CaseLoadsDummyDataA } from '../../server/data/localMockData/caseLoad'
+import { CaseLoad } from '../../server/interfaces/caseLoad'
 
 const placeHolderImagePath = './../../assets/images/average-face.jpg'
 
@@ -600,18 +601,18 @@ export default {
     })
   },
 
-  stubGetUserCaseLoad: () => {
+  stubUserCaseLoads: (caseLoads: CaseLoad[] = []) => {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/prison/api/users/me/caseLoads\\?allCaseloads=true',
+        urlPattern: `/prison/api/users/me/caseLoads\\?allCaseloads=true`,
       },
       response: {
         status: 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: CaseLoadsDummyDataA,
+        jsonBody: caseLoads.length > 0 ? caseLoads : CaseLoadsDummyDataA,
       },
     })
   },

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -63,3 +63,9 @@ Cypress.Commands.add('setupOffencesPageStubs', ({ prisonerNumber, bookingId }) =
   cy.task('stubGetSentenceTerms', bookingId)
   cy.task('stubGetPrisonerSentenceDetails', prisonerNumber)
 })
+
+Cypress.Commands.add('setupUserAuth', ({ roles, caseLoads }) => {
+  cy.task('stubSignIn', roles)
+  cy.task('stubUserCaseLoads', caseLoads)
+  cy.task('stubAuthUser')
+})

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -64,8 +64,8 @@ Cypress.Commands.add('setupOffencesPageStubs', ({ prisonerNumber, bookingId }) =
   cy.task('stubGetPrisonerSentenceDetails', prisonerNumber)
 })
 
-Cypress.Commands.add('setupUserAuth', ({ roles, caseLoads }) => {
+Cypress.Commands.add('setupUserAuth', ({ roles, caseLoads, activeCaseLoadId = 'MDI' }) => {
   cy.task('stubSignIn', roles)
   cy.task('stubUserCaseLoads', caseLoads)
-  cy.task('stubAuthUser')
+  cy.task('stubAuthUser', { activeCaseLoadId })
 })

--- a/server/mappers/headerMappers.ts
+++ b/server/mappers/headerMappers.ts
@@ -69,6 +69,7 @@ export function mapHeaderData(prisonerData: Prisoner, canViewCaseNotes?: boolean
     alerts: mapAlerts(prisonerData, alertFlagLabels),
     tabLinks: tabs,
     photoType,
+    prisonId: prisonerData.prisonId,
   }
   return headerData
 }

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express'
 import jwtDecode from 'jwt-decode'
 import logger from '../../logger'
 import UserService from '../services/userService'
+import { CaseLoad } from '../interfaces/caseLoad'
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
@@ -83,9 +84,16 @@ export function getUserActiveCaseLoad(userService: UserService): RequestHandler 
   return async (req, res, next) => {
     try {
       if (res.locals.user.activeCaseLoadId) {
-        const activeCaseLoad =
-          res.locals.user &&
-          (await userService.getUserCaseLoads(res.locals.user.token)).filter(caseLoad => caseLoad.currentlyActive)
+        let activeCaseLoad: CaseLoad[] | undefined
+
+        if (res.locals.user.caseLoads) {
+          activeCaseLoad = res.locals.user.caseLoads.filter((caseLoad: CaseLoad) => caseLoad.currentlyActive)
+        } else {
+          activeCaseLoad =
+            res.locals.user &&
+            (await userService.getUserCaseLoads(res.locals.user.token)).filter(caseLoad => caseLoad.currentlyActive)
+        }
+
         if (activeCaseLoad) {
           res.locals.user.activeCaseLoad = activeCaseLoad
         } else {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express'
+import jwtDecode from 'jwt-decode'
 import logger from '../../logger'
 import UserService from '../services/userService'
 
@@ -40,11 +41,11 @@ export function getUserLocations(userService: UserService): RequestHandler {
   }
 }
 
-export function getUserRoles(userService: UserService): RequestHandler {
+export function getUserRoles(): RequestHandler {
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
-        const roles = res.locals.user && (await userService.getUserRoles(res.locals.user.token))
+        const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
         if (roles) {
           res.locals.user.userRoles = roles
         } else {

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
-import populateCurrentUser, { getUserActiveCaseLoad, getUserRoles } from './populateCurrentUser'
+import populateCurrentUser, { getUserActiveCaseLoad, getUserCaseLoads, getUserRoles } from './populateCurrentUser'
 import type { Services } from '../services'
 
 export default function setUpCurrentUser({ userService }: Services): Router {
@@ -9,6 +9,7 @@ export default function setUpCurrentUser({ userService }: Services): Router {
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
   router.use(getUserActiveCaseLoad(userService))
-  router.use(getUserRoles(userService))
+  router.use(getUserCaseLoads(userService))
+  router.use(getUserRoles())
   return router
 }

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -8,8 +8,8 @@ export default function setUpCurrentUser({ userService }: Services): Router {
   const router = Router({ mergeParams: true })
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
-  router.use(getUserActiveCaseLoad(userService))
   router.use(getUserCaseLoads(userService))
+  router.use(getUserActiveCaseLoad(userService))
   router.use(getUserRoles())
   return router
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,7 +2,15 @@
 import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
-import { addressToLines, findError, formatScheduleItem, initialiseName, summaryListOneHalfWidth } from './utils'
+import {
+  addressToLines,
+  findError,
+  formatScheduleItem,
+  initialiseName,
+  prisonerBelongsToUsersCaseLoad,
+  summaryListOneHalfWidth,
+  userHasRoles,
+} from './utils'
 import { pluralise } from './pluralise'
 import { formatDate, formatDateTime } from './dateHelpers'
 import config from '../config'
@@ -46,6 +54,9 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     analytics: { tagManagerContainerId },
   } = config
   njkEnv.addGlobal('tagManagerContainerId', tagManagerContainerId.trim())
+
+  njkEnv.addGlobal('prisonerBelongsToUsersCaseLoad', prisonerBelongsToUsersCaseLoad)
+  njkEnv.addGlobal('userHasRoles', userHasRoles)
 
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('formatDate', formatDate)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -9,14 +9,17 @@ import {
   getNamesFromString,
   initialiseName,
   mapToQueryString,
+  prisonerBelongsToUsersCaseLoad,
   properCaseName,
   summaryListOneHalfWidth,
   SummaryListRow,
+  userHasRoles,
   yearsBetweenDateStrings,
 } from './utils'
 import { NameFormatStyle } from '../data/enums/nameFormatStyle'
 import { Address } from '../interfaces/address'
 import { HmppsError } from '../interfaces/hmppsError'
+import { CaseLoad } from '../interfaces/caseLoad'
 
 describe('convert to title case', () => {
   it.each([
@@ -274,5 +277,36 @@ describe('findError', () => {
     const errors: HmppsError[] = null
     const error = findError(errors, 'myError')
     expect(error).toBeNull()
+  })
+
+  describe('prisonerBelongsToUsersCaseLoad', () => {
+    it('Should return true when the user has a caseload matching the prisoner', () => {
+      const caseLoads: CaseLoad[] = [
+        { caseloadFunction: '', caseLoadId: 'ABC', currentlyActive: false, description: '', type: '' },
+        { caseloadFunction: '', caseLoadId: 'DEF', currentlyActive: false, description: '', type: '' },
+      ]
+
+      expect(prisonerBelongsToUsersCaseLoad('DEF', caseLoads)).toEqual(true)
+    })
+
+    it('Should return false when the user has a caseload that doesnt match the prisoner', () => {
+      const caseLoads: CaseLoad[] = [
+        { caseloadFunction: '', caseLoadId: 'ABC', currentlyActive: false, description: '', type: '' },
+        { caseloadFunction: '', caseLoadId: 'DEF', currentlyActive: false, description: '', type: '' },
+      ]
+
+      expect(prisonerBelongsToUsersCaseLoad('123', caseLoads)).toEqual(false)
+    })
+  })
+  describe('userHasRoles', () => {
+    it.each([
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['SOME_ROLE', 'GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH'], userRoles: [], result: false },
+      { roles: [], userRoles: ['GLOBAL_SEARCH'], result: false },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['SOME_ROLE'], result: true },
+    ])('Should return the correct result when checking user roles', ({ roles, userRoles, result }) => {
+      expect(userHasRoles(roles, userRoles)).toEqual(result)
+    })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -5,6 +5,7 @@ import { SortOption } from '../interfaces/sortSelector'
 import { Address } from '../interfaces/address'
 import { HmppsError } from '../interfaces/hmppsError'
 import { ListMetadata } from '../interfaces/listMetadata'
+import { CaseLoad } from '../interfaces/caseLoad'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -319,4 +320,25 @@ export const findError = (errors: HmppsError[], formFieldId: string) => {
     }
   }
   return null
+}
+
+/**
+ * Whether or not the prisoner belongs to any of the users case loads
+ *
+ * @param prisonerAgencyId
+ * @param userCaseLoads
+ */
+export const prisonerBelongsToUsersCaseLoad = (prisonerAgencyId: string, userCaseLoads: CaseLoad[]): boolean => {
+  return userCaseLoads.some(caseLoad => caseLoad.caseLoadId === prisonerAgencyId)
+}
+
+/**
+ * Whether any of the roles exist for the given user allowing for conditional role based access on any number of roles
+ *
+ * @param rolesToCheck
+ * @param userRoles
+ */
+
+export const userHasRoles = (rolesToCheck: string[], userRoles: string[]): boolean => {
+  return rolesToCheck.some(role => userRoles.includes(role))
 }

--- a/server/views/macros/conditionallyShow.njk
+++ b/server/views/macros/conditionallyShow.njk
@@ -1,0 +1,11 @@
+{% macro conditionallyShow(params) %}
+  {% if(params.condition) %}
+    <div data-qa="visible-{{ params.id }}">
+      {{ caller() }}
+    </div>
+  {% else %}
+    <div data-qa="hidden-{{ params.id }}">
+      {{ params.hiddenState | default("") }}
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/server/views/pages/personalPage.njk
+++ b/server/views/pages/personalPage.njk
@@ -1,3 +1,4 @@
+{% from "../macros/conditionallyShow.njk" import conditionallyShow %}
 {% extends "./index.njk" %}
 {% block body %}
   <div class="govuk-grid-row">
@@ -12,7 +13,9 @@
         <li><a class="govuk-link govuk-link--no-visited-state" href="#identity-numbers">Identity numbers</a></li>
         <li><a class="govuk-link govuk-link--no-visited-state" href="#care-needs">Care needs</a></li>
         <li><a class="govuk-link govuk-link--no-visited-state" href="#neurodiversity">Neurodiversity</a></li>
-        <li><a class="govuk-link govuk-link--no-visited-state" href="#appearance">Appearance</a></li>
+        {%- call conditionallyShow({condition: prisonerBelongsToUsersCaseLoad(prisonId, user.caseLoads), id: 'appearance'}) -%}
+          <li><a class="govuk-link govuk-link--no-visited-state" href="#appearance">Appearance</a></li>
+        {%- endcall -%}
         <li><a class="govuk-link govuk-link--no-visited-state" href="#addresses">Addresses</a></li>
         <li><a class="govuk-link govuk-link--no-visited-state" href="#next-of-kin">Next of kin</a></li>
         <li><a class="govuk-link govuk-link--no-visited-state" href="#security">Security</a></li>
@@ -41,11 +44,13 @@
           {% include "../partials/personalPage/neurodiversity.njk" %}
         </div>
       </div> #}
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          {% include "../partials/personalPage/appearance.njk" %}
+      {%- call conditionallyShow({condition: prisonerBelongsToUsersCaseLoad(prisonId, user.caseLoads), id: 'appearance'}) -%}
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            {% include "../partials/personalPage/appearance.njk" %}
+          </div>
         </div>
-      </div>
+      {%- endcall -%}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           {% include "../partials/personalPage/addresses.njk" %}


### PR DESCRIPTION
This PR creates the scaffolding in production and test code for us to be able to add conditional viewing. 

The frontend macro for this allows for:
- Showing/Hiding content based on a condition passed in
  - E.g. Checking for roles, case loads, etc
- Showing placeholder content if the condition isnt met
- Putting data in for E2E tests to read whether or not something has been conditionally shown (e.g. `data-qa='hidden-X'`)

Additionally this sets up the middleware for letting us check users roles and caseloads