### PR TITLE
Increasing number of pods in production to 4

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,7 +2,7 @@
 # Per environment values which override defaults in hmpps-prisoner-profile/values.yaml
 
 generic-service:
-  replicaCount: 2
+  replicaCount: 4
 
   ingress:
     host: prisoner.digital.prison.service.justice.gov.uk


### PR DESCRIPTION
4 is the standard number of pods we use in production.