### PR TITLE
NON-160 filter inactive and NA in a different prison

### DIFF
--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -69,7 +69,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details`,
+        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true`,
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -69,7 +69,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details`,
+        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details.*`,
       },
       response: {
         status: 200,

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -69,7 +69,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true`,
+        urlPattern: `/prison/api/offenders/${prisonerNumber}/non-association-details`,
       },
       response: {
         status: 200,

--- a/server/data/localMockData/nonAssociations.ts
+++ b/server/data/localMockData/nonAssociations.ts
@@ -6,9 +6,9 @@ const nonAssociationA: NonAssociation = {
   lastName: 'Doe',
   reasonCode: 'VIC',
   reasonDescription: 'Victim',
+  agencyId: 'MDI',
   agencyDescription: 'Moorland (HMP & YOI)',
   assignedLivingUnitDescription: 'NMI-RECP',
-  assignedLivingUnitId: 1234,
 }
 
 const nonAssociationDetailA: NonAssociationDetail = {
@@ -29,9 +29,9 @@ const nonAssociationB: NonAssociation = {
   lastName: 'Incognito',
   reasonCode: 'RIV',
   reasonDescription: 'Rival Gang',
+  agencyId: 'MDI',
   agencyDescription: 'Moorland (HMP & YOI)',
   assignedLivingUnitDescription: 'NMI-RECP',
-  assignedLivingUnitId: 1234,
 }
 
 const nonAssociationDetailB: NonAssociationDetail = {
@@ -50,9 +50,9 @@ const nonAssociationDetailsDummyData: NonAssociationDetails = {
   offenderNo: 'G6123VU',
   firstName: 'John',
   lastName: 'Saunders',
+  agencyId: 'MDI',
   agencyDescription: 'Moorland (HMP & YOI)',
   assignedLivingUnitDescription: 'MDI-5-1-A-012',
-  assignedLivingUnitId: 26019,
   nonAssociations: [nonAssociationDetailA, nonAssociationDetailB],
 }
 

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -67,7 +67,7 @@ describe('prisonApiClient', () => {
   describe('getNonAssociations', () => {
     it.each(['ABC12', 'DEF456'])('Should return data from the API', async prisonerNumber => {
       mockSuccessfulPrisonApiCall(
-        `/api/offenders/${prisonerNumber}/non-association-details`,
+        `/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true`,
         nonAssociationDetailsDummyData,
       )
 

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -82,7 +82,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
 
   async getNonAssociationDetails(prisonerNumber: string): Promise<NonAssociationDetails> {
     return this.get<NonAssociationDetails>(
-      { path: `/api/offenders/${prisonerNumber}/non-association-details` },
+      { path: `/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true` },
       nonAssociationDetailsDummyData,
     )
   }

--- a/server/interfaces/nonAssociationDetails.ts
+++ b/server/interfaces/nonAssociationDetails.ts
@@ -2,9 +2,9 @@ export type NonAssociation = {
   offenderNo: string
   firstName: string
   lastName: string
+  agencyId: string
   agencyDescription: string
   assignedLivingUnitDescription: string
-  assignedLivingUnitId: number
   reasonCode: string
   reasonDescription: string
 }
@@ -25,8 +25,8 @@ export type NonAssociationDetails = {
   offenderNo: string
   firstName: string
   lastName: string
+  agencyId: string
   agencyDescription: string
   assignedLivingUnitDescription: string
   nonAssociations: NonAssociationDetail[]
-  assignedLivingUnitId: number
 }

--- a/server/services/overviewPageService.test.ts
+++ b/server/services/overviewPageService.test.ts
@@ -134,17 +134,6 @@ describe('OverviewPageService', () => {
       expect(associationRowTwo[3].text).toEqual('Rival Gang')
     })
 
-    it('Only shows non associations that are part of the same prison', async () => {
-      const nonAssocations = { ...nonAssociationDetailsDummyData }
-      nonAssocations.nonAssociations[0].offenderNonAssociation.agencyDescription = 'Somewhere else'
-      prisonApiClient.getNonAssociationDetails = jest.fn(async () => nonAssocations)
-      const overviewPageService = overviewPageServiceConstruct()
-      const res = await overviewPageService.get('token', { prisonerNumber: 'ABC123' } as Prisoner, 1)
-      const expectedPrisonNumber = nonAssocations.nonAssociations[1].offenderNonAssociation.offenderNo
-      expect(res.nonAssociations.length).toEqual(1)
-      expect(res.nonAssociations[0][1].text).toEqual(expectedPrisonNumber)
-    })
-
     it('Returns an empty list if no non-associations are returned', async () => {
       const nonAssocations = { ...nonAssociationDetailsDummyData }
       nonAssocations.nonAssociations = []

--- a/server/services/overviewPageService.ts
+++ b/server/services/overviewPageService.ts
@@ -148,8 +148,7 @@ export default class OverviewPageService {
   }
 
   async getMainOffenceDescription(mainOffence: MainOffence[]): Promise<string> {
-    const desc = mainOffence[0] && mainOffence[0].offenceDescription ? mainOffence[0].offenceDescription : 'Not entered'
-    return desc
+    return mainOffence[0] && mainOffence[0].offenceDescription ? mainOffence[0].offenceDescription : 'Not entered'
   }
 
   async getNextCourtAppearanceForOverview(courtCaseData: CourtCase[]) {
@@ -206,7 +205,7 @@ export default class OverviewPageService {
       (allocationManager as Pom).secondary_pom.name &&
       getNamesFromString((allocationManager as Pom).secondary_pom.name)
 
-    const staffContacts = {
+    return {
       keyWorker: {
         name:
           offenderKeyWorker && offenderKeyWorker.firstName
@@ -233,8 +232,6 @@ export default class OverviewPageService {
           : 'Not assigned',
       linkUrl: `${config.serviceUrls.digitalPrison}/prisoner/${prisonerData.prisonerNumber}/professional-contacts`,
     }
-
-    return staffContacts
   }
 
   public async getPersonalDetails(prisonerData: Prisoner): Promise<PersonalDetails> {
@@ -512,22 +509,18 @@ export default class OverviewPageService {
     const nonAssociations = await this.prisonApiClient.getNonAssociationDetails(prisonerNumber)
     if (!nonAssociations?.nonAssociations) return []
 
-    return nonAssociations.nonAssociations
-      .filter(nonassociation => {
-        return nonassociation.offenderNonAssociation.agencyDescription === nonAssociations.agencyDescription
-      })
-      .map(nonAssocation => {
-        const { offenderNonAssociation } = nonAssocation
-        const nonAssociationName = `${offenderNonAssociation.firstName} ${offenderNonAssociation.lastName}`
-        return [
-          {
-            html: `<a class="govuk-link govuk-link--no-visited-state" href="/prisoner/${offenderNonAssociation.offenderNo}">${nonAssociationName}</a>`,
-          },
-          { text: offenderNonAssociation.offenderNo },
-          { text: offenderNonAssociation.assignedLivingUnitDescription },
-          { text: offenderNonAssociation.reasonDescription },
-        ]
-      })
+    return nonAssociations.nonAssociations.map(nonAssocation => {
+      const { offenderNonAssociation } = nonAssocation
+      const nonAssociationName = `${offenderNonAssociation.firstName} ${offenderNonAssociation.lastName}`
+      return [
+        {
+          html: `<a class="govuk-link govuk-link--no-visited-state" href="/prisoner/${offenderNonAssociation.offenderNo}">${nonAssociationName}</a>`,
+        },
+        { text: offenderNonAssociation.offenderNo },
+        { text: offenderNonAssociation.assignedLivingUnitDescription },
+        { text: offenderNonAssociation.reasonDescription },
+      ]
+    })
   }
 
   private async getStatuses(prisonerData: Prisoner): Promise<Status[]> {


### PR DESCRIPTION
As NA API endpoint now can filter by current prison and also active only - making use of this to simplify the code