### PR TITLE
NON-261: Show link for non-associations private beta prisons

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -39,7 +39,7 @@ generic-service:
     FEEDBACK_DISABLED_PRISONS: "LEI,FNI,RSI,HMI,NHI"
     ENVIRONMENT_NAME: "DEV"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: "LGI,FNI,ISI,RSI"
+    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api-dev.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities-dev.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -39,7 +39,7 @@ generic-service:
     FEEDBACK_DISABLED_PRISONS: "LEI,FNI,RSI,HMI,NHI"
     ENVIRONMENT_NAME: "PRE-PRODUCTION"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: "LGI,FNI,ISI,RSI"
+    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api-preprod.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities-preprod.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "RSI"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -38,7 +38,7 @@ generic-service:
     NON_ASSOCIATIONS_UI_URL: "https://non-associations.hmpps.service.justice.gov.uk"
     FEEDBACK_DISABLED_PRISONS: "LEI,FNI,RSI,HMI,NHI"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: ""
+    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "RSI"


### PR DESCRIPTION
The 'Alerts' section will show the link to the prisoner non-associations in the following prisons: FNI,ISI,LGI,RSI

**NOTE**: This can't be merged/deployed until we start the private beta in these prisons. We'll keep this PR in draft until then.