### PR TITLE
CDPS-387: Remove local mock data

### DIFF
--- a/integration_tests/e2e/addAlertPage.cy.ts
+++ b/integration_tests/e2e/addAlertPage.cy.ts
@@ -13,6 +13,7 @@ const visitAlertsPage = (): AlertsPage => {
 context('Add Alert Page', () => {
   beforeEach(() => {
     cy.task('reset')
+    cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
     cy.setupUserAuth({ roles: [Role.GlobalSearch, Role.UpdateAlert] })
   })
 
@@ -21,6 +22,7 @@ context('Add Alert Page', () => {
     let addAlertPage: AddAlertPage
 
     beforeEach(() => {
+      cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
       cy.setupAlertsPageStubs({ prisonerNumber: 'G6123VU', bookingId: 1102484 })
       cy.task('stubGetAlertTypes')
       cy.task('stubCreateAlert')

--- a/integration_tests/e2e/addCaseNotePage.cy.ts
+++ b/integration_tests/e2e/addCaseNotePage.cy.ts
@@ -14,6 +14,8 @@ context('Add Case Note Page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.setupUserAuth()
+    cy.task('stubGetCaseNotes', 'G6123VU')
+    cy.task('stubGetCaseNotesUsage', 'G6123VU')
     cy.task('stubGetCaseNoteTypes')
     cy.task('stubGetCaseNoteTypesForUser')
     cy.task('stubAddCaseNote')

--- a/integration_tests/e2e/alertsPage.cy.ts
+++ b/integration_tests/e2e/alertsPage.cy.ts
@@ -19,6 +19,7 @@ const visitEmptyAlertsPage = () => {
 context('Alerts Page - Permissions', () => {
   context('Active alerts', () => {
     const visitPage = prisonerDataOverrides => {
+      cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
       cy.setupAlertsPageStubs({ prisonerNumber: 'G6123VU', bookingId: 1102484, prisonerDataOverrides })
       visitActiveAlertsPage({ failOnStatusCode: false })
     }
@@ -35,6 +36,7 @@ context('Alerts Page - User does not have Update Alerts role', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.setupUserAuth()
+    cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
   })
 
   context('Active Alerts', () => {
@@ -119,6 +121,7 @@ context('Alerts Page - User does not have Update Alerts role', () => {
 
     beforeEach(() => {
       cy.setupAlertsPageStubs({ prisonerNumber: 'A1234BC', bookingId: 1234567 })
+      cy.setupBannerStubs({ prisonerNumber: 'G6123VU', bookingId: 1234567 })
       visitEmptyAlertsPage()
       alertsPage = Page.verifyOnPageWithTitle(AlertsPage, 'Active alerts')
     })
@@ -209,6 +212,7 @@ context('Alerts Page - User has Update Alert role', () => {
       roles: [Role.PrisonUser, Role.UpdateAlert],
       caseLoads: [{ caseloadFunction: '', caseLoadId: 'MDI', currentlyActive: true, description: '', type: '' }],
     })
+    cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
     cy.setupAlertsPageStubs({ prisonerNumber: 'G6123VU', bookingId: 1102484 })
     visitActiveAlertsPage()
     alertsPage = Page.verifyOnPageWithTitle(AlertsPage, 'Active alerts')

--- a/integration_tests/e2e/personalPage.cy.ts
+++ b/integration_tests/e2e/personalPage.cy.ts
@@ -45,6 +45,7 @@ context('When signed in', () => {
       cy.task('stubHealthTreatmentReferenceDomain')
       cy.task('stubReasonableAdjustments', 1102484)
       cy.task('stubPersonalCareNeeds', 1102484)
+      cy.task('stubIdentifiers', 1102484)
       visitPersonalDetailsPage()
     })
 

--- a/integration_tests/e2e/photoPage.cy.ts
+++ b/integration_tests/e2e/photoPage.cy.ts
@@ -8,14 +8,17 @@ context('Photo Page', () => {
   const bookingId = 1102484
 
   context('Permissions', () => {
-    const visitPage = () => cy.signIn({ failOnStatusCode: false, redirectPath: 'prisoner/G6123VU/image' })
+    const visitPage = prisonerDataOverrides => {
+      cy.setupBannerStubs({ prisonerNumber, bookingId, prisonerDataOverrides })
+      cy.signIn({ failOnStatusCode: false, redirectPath: 'prisoner/G6123VU/image' })
+    }
     permissionsTests({ prisonerNumber, visitPage, pageToDisplay: PrisonerPhotoPage })
   })
 
   beforeEach(() => {
     cy.task('reset')
     cy.setupUserAuth()
-    cy.setupBannerStubs({ prisonerNumber })
+    cy.setupBannerStubs({ prisonerNumber, bookingId })
     cy.setupOverviewPageStubs({ prisonerNumber, bookingId })
   })
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -13,6 +13,7 @@ declare global {
       setupBannerStubs(options: {
         prisonerNumber: string
         prisonerDataOverrides?: Partial<Prisoner>
+        bookingId?: number
       }): Chainable<AUTWindow>
       setupOverviewPageStubs(options: {
         prisonerNumber: string

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -914,7 +914,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/prison/api/agencies/${agencyId}\\?activeOnly=false`,
+        urlPattern: `/prison/api/agencies/${agencyId}\\?.*`,
       },
       response: {
         status: 200,
@@ -1129,6 +1129,22 @@ export default {
           'Content-Type': 'application/json;charset=UTF-8',
         },
         jsonBody: OffenderAttendanceHistoryMock(),
+      },
+    })
+  },
+
+  stubIdentifiers: (bookingId: number) => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/prison/api/bookings/${bookingId}/identifiers`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: identifiersMock,
       },
     })
   },

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -4,9 +4,11 @@ Cypress.Commands.add('signIn', (options = { failOnStatusCode: true, redirectPath
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, { failOnStatusCode }))
 })
 
-Cypress.Commands.add('setupBannerStubs', ({ prisonerNumber, prisonerDataOverrides }) => {
+Cypress.Commands.add('setupBannerStubs', ({ prisonerNumber, prisonerDataOverrides, bookingId = 1102484 }) => {
   cy.task('stubPrisonerData', { prisonerNumber, overrides: prisonerDataOverrides })
   cy.task('stubEventsForProfileImage', prisonerNumber)
+  cy.task('stubAssessments', bookingId)
+  cy.task('stubInmateDetail', bookingId)
 })
 
 Cypress.Commands.add(

--- a/server/controllers/prisonerScheduleController.test.ts
+++ b/server/controllers/prisonerScheduleController.test.ts
@@ -1,17 +1,14 @@
 import { PrisonerMockDataA } from '../data/localMockData/prisoner'
 import { inmateDetailMock } from '../data/localMockData/inmateDetailMock'
 import PrisonerScheduleController from './prisonerScheduleController'
-import { dataAccess } from '../data'
 import { PrisonerScheduleThisWeekMock } from '../data/localMockData/prisonerScheduleMock'
 import { getEventsNextWeekMock, getEventsThisWeekMock } from '../data/localMockData/getEventsMock'
+import { prisonApiClientMock } from '../../tests/mocks/prisonApiClientMock'
+import { PrisonApiClient } from '../data/interfaces/prisonApiClient'
 
 describe('Prisoner schedule', () => {
   const offenderNo = 'ABC123'
-  const prisonApi = {
-    getDetails: jest.fn(),
-    getScheduledEventsForThisWeek: jest.fn(),
-    getScheduledEventsForNextWeek: jest.fn(),
-  }
+  let prisonApi: PrisonApiClient
 
   let req: any
   let res: any
@@ -31,9 +28,10 @@ describe('Prisoner schedule', () => {
     }
     res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
+    prisonApi = prisonApiClientMock()
     prisonApi.getScheduledEventsForThisWeek = jest.fn().mockResolvedValue(getEventsThisWeekMock)
     prisonApi.getScheduledEventsForNextWeek = jest.fn().mockResolvedValue(getEventsNextWeekMock)
-    controller = new PrisonerScheduleController(dataAccess.prisonApiClientBuilder)
+    controller = new PrisonerScheduleController(() => prisonApi)
   })
 
   afterEach(() => {

--- a/server/data/adjudicationsApiClient.ts
+++ b/server/data/adjudicationsApiClient.ts
@@ -10,18 +10,7 @@ export default class AdjudicationsApiRestClient implements AdjudicationsApiClien
     this.restClient = new RestClient('Adjudications API', config.apis.adjudicationsApi, token)
   }
 
-  private async get<T>(args: object, localMockData?: T): Promise<T> {
-    try {
-      return await this.restClient.get<T>(args)
-    } catch (error) {
-      if (config.localMockData === 'true' && localMockData) {
-        return localMockData
-      }
-      return error
-    }
-  }
-
   async getAdjudications(bookingId: number): Promise<AdjudicationSummary> {
-    return this.get<AdjudicationSummary>({ path: `/adjudications/by-booking-id/${bookingId}` })
+    return this.restClient.get<AdjudicationSummary>({ path: `/adjudications/by-booking-id/${bookingId}` })
   }
 }

--- a/server/data/curiousApiClient.ts
+++ b/server/data/curiousApiClient.ts
@@ -15,54 +15,43 @@ export default class CuriousRestApiClient implements CuriousApiClient {
     this.restClient = new RestClient('Curious API', config.apis.curiousApiUrl, token)
   }
 
-  private async get<T>(args: object, localMockData?: T): Promise<T> {
-    try {
-      return await this.restClient.get<T>(args)
-    } catch (error) {
-      if (config.localMockData === 'true' && localMockData) {
-        return localMockData
-      }
-      return error
-    }
-  }
-
   async getLearnerEmployabilitySkills(offenderNumber: string): Promise<LearnerEmployabilitySkills> {
-    return this.get<LearnerEmployabilitySkills>({
+    return this.restClient.get<LearnerEmployabilitySkills>({
       path: `/learnerEmployabilitySkills/${offenderNumber}`,
       ignore404: true,
     })
   }
 
   async getLearnerProfile(offenderNumber: string): Promise<LearnerProfile[]> {
-    return this.get<LearnerProfile[]>({
+    return this.restClient.get<LearnerProfile[]>({
       path: `/learnerProfile/${offenderNumber}`,
       ignore404: true,
     })
   }
 
   async getLearnerEducation(offenderNumber: string): Promise<LearnerEducation> {
-    return this.get<LearnerEducation>({
+    return this.restClient.get<LearnerEducation>({
       path: `/learnerEducation/${offenderNumber}`,
       ignore404: true,
     })
   }
 
   async getLearnerLatestAssessments(offenderNumber: string): Promise<LearnerLatestAssessment[]> {
-    return this.get<LearnerLatestAssessment[]>({
+    return this.restClient.get<LearnerLatestAssessment[]>({
       path: `/latestLearnerAssessments/${offenderNumber}`,
       ignore404: true,
     })
   }
 
   async getLearnerGoals(offenderNumber: string): Promise<LearnerGoals> {
-    return this.get<LearnerGoals>({
+    return this.restClient.get<LearnerGoals>({
       path: `/learnerGoals/${offenderNumber}`,
       ignore404: true,
     })
   }
 
   async getLearnerNeurodivergence(offenderNumber: string): Promise<LearnerNeurodivergence[]> {
-    return this.get<LearnerNeurodivergence[]>({
+    return this.restClient.get<LearnerNeurodivergence[]>({
       path: `/learnerNeurodivergence/${offenderNumber}`,
       ignore404: true,
     })

--- a/server/data/incentivesApiClient.ts
+++ b/server/data/incentivesApiClient.ts
@@ -10,19 +10,8 @@ export default class IncentivesApiRestClient implements IncentivesApiClient {
     this.restClient = new RestClient('Incentives API', config.apis.incentivesApi, token)
   }
 
-  private async get<T>(args: object, localMockData?: T): Promise<T> {
-    try {
-      return await this.restClient.get<T>(args)
-    } catch (error) {
-      if (config.localMockData === 'true' && localMockData) {
-        return localMockData
-      }
-      return error
-    }
-  }
-
   async getReviews(bookingId: number): Promise<IncentiveReviews> {
-    return this.get<IncentiveReviews>({
+    return this.restClient.get<IncentiveReviews>({
       path: `/iep/reviews/booking/${bookingId}`,
       ignore404: true,
     })

--- a/server/data/interfaces/prisonApiClient.ts
+++ b/server/data/interfaces/prisonApiClient.ts
@@ -49,7 +49,7 @@ export interface PrisonApiClient {
   getUserCaseLoads(): Promise<CaseLoad[]>
   getAccountBalances(bookingId: number): Promise<AccountBalances>
   getVisitSummary(bookingId: number): Promise<VisitSummary>
-  getVisitBalances(prisonerNumber: string): Promise<VisitBalances>
+  getVisitBalances(prisonerNumber: string): Promise<VisitBalances | null>
   getAssessments(bookingId: number): Promise<Assessment[]>
   getBookingContacts(bookingId: number): Promise<ContactDetail>
   getCaseNoteSummaryByTypes(params: object): Promise<CaseNote[]>

--- a/server/data/nonAssociationsApiClient.ts
+++ b/server/data/nonAssociationsApiClient.ts
@@ -1,7 +1,6 @@
 import config from '../config'
 import { NonAssociationDetails } from '../interfaces/nonAssociationDetails'
 import { NonAssociationsApiClient } from './interfaces/nonAssociationsApiClient'
-import nonAssociationDetailsDummyData from './localMockData/nonAssociations'
 import RestClient from './restClient'
 
 export default class NonAssociationsApiRestClient implements NonAssociationsApiClient {
@@ -11,23 +10,9 @@ export default class NonAssociationsApiRestClient implements NonAssociationsApiC
     this.restClient = new RestClient('Non associations API', config.apis.nonAssociationsApi, token)
   }
 
-  private async get<T>(args: object, localMockData?: T): Promise<T> {
-    try {
-      return await this.restClient.get<T>(args)
-    } catch (error) {
-      if (config.localMockData === 'true' && localMockData) {
-        return localMockData
-      }
-      return error
-    }
-  }
-
   getNonAssociationDetails(prisonerNumber: string): Promise<NonAssociationDetails> {
-    return this.get<NonAssociationDetails>(
-      {
-        path: `/legacy/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true`,
-      },
-      nonAssociationDetailsDummyData,
-    )
+    return this.restClient.get<NonAssociationDetails>({
+      path: `/legacy/api/offenders/${prisonerNumber}/non-association-details?currentPrisonOnly=true&excludeInactive=true`,
+    })
   }
 }

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -1,7 +1,6 @@
 import { Readable } from 'stream'
 import config from '../config'
 import RestClient from './restClient'
-import { CaseLoadsDummyDataA } from './localMockData/caseLoad'
 import { CaseLoad } from '../interfaces/caseLoad'
 import { PrisonApiClient } from './interfaces/prisonApiClient'
 import { AccountBalances } from '../interfaces/accountBalances'
@@ -12,7 +11,6 @@ import { ContactDetail } from '../interfaces/staffContacts'
 import { mapToQueryString } from '../utils/utils'
 import { CaseNote } from '../interfaces/caseNote'
 import { ScheduledEvent } from '../interfaces/scheduledEvent'
-import dummyScheduledEvents from './localMockData/eventsForToday'
 import { PrisonerDetail } from '../interfaces/prisonerDetail'
 import { InmateDetail } from '../interfaces/prisonApi/inmateDetail'
 import { PersonalCareNeeds } from '../interfaces/personalCareNeeds'
@@ -59,15 +57,8 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     this.restClient = new RestClient('Prison API', config.apis.prisonApi, token)
   }
 
-  private async get<T>(args: object, localMockData?: T): Promise<T> {
-    try {
-      return await this.restClient.get<T>(args)
-    } catch (error) {
-      if (config.localMockData === 'true' && localMockData) {
-        return localMockData
-      }
-      return error
-    }
+  private async get<T>(args: object): Promise<T> {
+    return this.restClient.get<T>(args)
   }
 
   private async post(args: object): Promise<unknown> {
@@ -85,7 +76,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getUserCaseLoads(): Promise<CaseLoad[]> {
-    return this.get<CaseLoad[]>({ path: '/api/users/me/caseLoads', query: 'allCaseloads=true' }, CaseLoadsDummyDataA)
+    return this.get<CaseLoad[]>({ path: '/api/users/me/caseLoads', query: 'allCaseloads=true' })
   }
 
   async getPrisonerImage(offenderNumber: string, fullSizeImage: boolean): Promise<Readable> {
@@ -119,12 +110,9 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getEventsScheduledForToday(bookingId: number): Promise<ScheduledEvent[]> {
-    return this.get<ScheduledEvent[]>(
-      {
-        path: `/api/bookings/${bookingId}/events/today`,
-      },
-      dummyScheduledEvents,
-    )
+    return this.get<ScheduledEvent[]>({
+      path: `/api/bookings/${bookingId}/events/today`,
+    })
   }
 
   async getBookingContacts(bookingId: number): Promise<ContactDetail> {

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -57,10 +57,6 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     this.restClient = new RestClient('Prison API', config.apis.prisonApi, token)
   }
 
-  private async get<T>(args: object): Promise<T> {
-    return this.restClient.get<T>(args)
-  }
-
   private async post(args: object): Promise<unknown> {
     return this.restClient.post(args)
   }
@@ -70,13 +66,13 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     fromDate: string,
     toDate: string,
   ): Promise<OffenderAttendanceHistory> {
-    return this.get<OffenderAttendanceHistory>({
+    return this.restClient.get<OffenderAttendanceHistory>({
       path: `/api/offender-activities/${prisonerNumber}/attendance-history?fromDate=${fromDate}&toDate=${toDate}&page=0&size=1000`,
     })
   }
 
   async getUserCaseLoads(): Promise<CaseLoad[]> {
-    return this.get<CaseLoad[]>({ path: '/api/users/me/caseLoads', query: 'allCaseloads=true' })
+    return this.restClient.get<CaseLoad[]>({ path: '/api/users/me/caseLoads', query: 'allCaseloads=true' })
   }
 
   async getPrisonerImage(offenderNumber: string, fullSizeImage: boolean): Promise<Readable> {
@@ -90,28 +86,28 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getAccountBalances(bookingId: number): Promise<AccountBalances> {
-    return this.get<AccountBalances>({
+    return this.restClient.get<AccountBalances>({
       path: `/api/bookings/${bookingId}/balances`,
     })
   }
 
   async getVisitSummary(bookingId: number): Promise<VisitSummary> {
-    return this.get<VisitSummary>({ path: `/api/bookings/${bookingId}/visits/summary` })
+    return this.restClient.get<VisitSummary>({ path: `/api/bookings/${bookingId}/visits/summary` })
   }
 
   async getVisitBalances(prisonerNumber: string): Promise<VisitBalances | null> {
-    return this.get<VisitBalances | null>({
+    return this.restClient.get<VisitBalances | null>({
       path: `/api/bookings/offenderNo/${prisonerNumber}/visit/balances`,
       ignore404: true,
     })
   }
 
   async getAssessments(bookingId: number): Promise<Assessment[]> {
-    return this.get<Assessment[]>({ path: `/api/bookings/${bookingId}/assessments` })
+    return this.restClient.get<Assessment[]>({ path: `/api/bookings/${bookingId}/assessments` })
   }
 
   async getEventsScheduledForToday(bookingId: number): Promise<ScheduledEvent[]> {
-    return this.get<ScheduledEvent[]>({
+    return this.restClient.get<ScheduledEvent[]>({
       path: `/api/bookings/${bookingId}/events/today`,
     })
   }
@@ -125,7 +121,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getPrisoner(prisonerNumber: string): Promise<PrisonerDetail> {
-    const prisoner = await this.get<PrisonerDetail>({ path: `/api/prisoners/${prisonerNumber}` })
+    const prisoner = await this.restClient.get<PrisonerDetail>({ path: `/api/prisoners/${prisonerNumber}` })
     // API returns array with one entry, so extract this to return a single object
     if (Array.isArray(prisoner)) {
       return prisoner[0]
@@ -142,7 +138,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getInmateDetail(bookingId: number): Promise<InmateDetail> {
-    return this.get<InmateDetail>({ path: `/api/bookings/${bookingId}` })
+    return this.restClient.get<InmateDetail>({ path: `/api/bookings/${bookingId}` })
   }
 
   async getPersonalCareNeeds(bookingId: number, types?: string[]): Promise<PersonalCareNeeds> {
@@ -150,7 +146,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     if (types?.length) {
       query = `type=${types.join()}`
     }
-    return this.get<PersonalCareNeeds>({ path: `/api/bookings/${bookingId}/personal-care-needs`, query })
+    return this.restClient.get<PersonalCareNeeds>({ path: `/api/bookings/${bookingId}/personal-care-needs`, query })
   }
 
   async getOffenderActivitiesHistory(
@@ -167,7 +163,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getSecondaryLanguages(bookingId: number): Promise<SecondaryLanguage[]> {
-    return this.get<SecondaryLanguage[]>({ path: `/api/bookings/${bookingId}/secondary-languages` })
+    return this.restClient.get<SecondaryLanguage[]>({ path: `/api/bookings/${bookingId}/secondary-languages` })
   }
 
   async getAlerts(bookingId: number, queryParams?: PagedListQueryParams): Promise<PagedList<Alert>> {
@@ -176,45 +172,50 @@ export default class PrisonApiRestClient implements PrisonApiClient {
       size: queryParams?.showAll ? 9999 : 20,
       ...queryParams,
     }
-    return this.get<PagedList<Alert>>({ path: `/api/bookings/${bookingId}/alerts/v2`, query: mapToQueryString(params) })
+    return this.restClient.get<PagedList<Alert>>({
+      path: `/api/bookings/${bookingId}/alerts/v2`,
+      query: mapToQueryString(params),
+    })
   }
 
   async getProperty(bookingId: number): Promise<PropertyContainer[]> {
-    return this.get<PropertyContainer[]>({ path: `/api/bookings/${bookingId}/property` })
+    return this.restClient.get<PropertyContainer[]>({ path: `/api/bookings/${bookingId}/property` })
   }
 
   async getCourtCases(bookingId: number): Promise<CourtCase[]> {
-    return this.get<CourtCase[]>({ path: `/api/bookings/${bookingId}/court-cases` })
+    return this.restClient.get<CourtCase[]>({ path: `/api/bookings/${bookingId}/court-cases` })
   }
 
   async getOffenceHistory(prisonerNumber: string): Promise<OffenceHistoryDetail[]> {
-    return this.get<OffenceHistoryDetail[]>({ path: `/api/bookings/offenderNo/${prisonerNumber}/offenceHistory` })
+    return this.restClient.get<OffenceHistoryDetail[]>({
+      path: `/api/bookings/offenderNo/${prisonerNumber}/offenceHistory`,
+    })
   }
 
   async getSentenceTerms(bookingId: number): Promise<OffenderSentenceTerms[]> {
-    return this.get<OffenderSentenceTerms[]>({
+    return this.restClient.get<OffenderSentenceTerms[]>({
       path: `/api/offender-sentences/booking/${bookingId}/sentenceTerms?filterBySentenceTermCodes=IMP&filterBySentenceTermCodes=LIC`,
     })
   }
 
   async getPrisonerSentenceDetails(prisonerNumber: string): Promise<PrisonerSentenceDetails> {
     try {
-      return this.get<PrisonerSentenceDetails>({ path: `/api/offenders/${prisonerNumber}/sentences` })
+      return this.restClient.get<PrisonerSentenceDetails>({ path: `/api/offenders/${prisonerNumber}/sentences` })
     } catch (error) {
       return error
     }
   }
 
   async getAddresses(prisonerNumber: string): Promise<Address[]> {
-    return this.get<Address[]>({ path: `/api/offenders/${prisonerNumber}/addresses` })
+    return this.restClient.get<Address[]>({ path: `/api/offenders/${prisonerNumber}/addresses` })
   }
 
   async getAddressesForPerson(personId: number): Promise<Address[]> {
-    return this.get<Address[]>({ path: `/api/persons/${personId}/addresses` })
+    return this.restClient.get<Address[]>({ path: `/api/persons/${personId}/addresses` })
   }
 
   async getOffenderContacts(prisonerNumber: string): Promise<OffenderContacts> {
-    return this.get<OffenderContacts>({ path: `/api/offenders/${prisonerNumber}/contacts` })
+    return this.restClient.get<OffenderContacts>({ path: `/api/offenders/${prisonerNumber}/contacts` })
   }
 
   async getImage(imageId: string, getFullSizedImage: boolean): Promise<Readable> {
@@ -228,21 +229,21 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getReferenceCodesByDomain(domain: ReferenceCodeDomain): Promise<ReferenceCode[]> {
-    return this.get<ReferenceCode[]>({
+    return this.restClient.get<ReferenceCode[]>({
       path: `/api/reference-domains/domains/${domain}`,
       headers: { 'page-limit': '1000' },
     })
   }
 
   async getReasonableAdjustments(bookingId: number, treatmentCodes: string[]): Promise<ReasonableAdjustments> {
-    return this.get<ReasonableAdjustments>({
+    return this.restClient.get<ReasonableAdjustments>({
       path: `/api/bookings/${bookingId}/reasonable-adjustments?type=${treatmentCodes.join()}`,
     })
   }
 
   async getCaseNotesUsage(prisonerNumber: string): Promise<CaseNoteUsage[]> {
     const today = formatDateISO(new Date())
-    return this.get({
+    return this.restClient.get({
       path: `/api/case-notes/usage`,
       query: `offenderNo=${prisonerNumber}&toDate=${today}&numMonths=1200`,
     })
@@ -255,106 +256,111 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     fromDate: string,
     toDate: string,
   ): Promise<CaseNoteCount> {
-    return this.get({
+    return this.restClient.get({
       path: `/api/bookings/${bookingId}/caseNotes/${type}/${subType}/count`,
       query: `fromDate=${fromDate}&toDate=${toDate}`,
     })
   }
 
   async getMainOffence(bookingId: number): Promise<MainOffence[]> {
-    return this.get({ path: `/api/bookings/${bookingId}/mainOffence` })
+    return this.restClient.get({ path: `/api/bookings/${bookingId}/mainOffence` })
   }
 
   async getFullStatus(prisonerNumber: string): Promise<FullStatus> {
-    return this.get({ path: `/api/prisoners/${prisonerNumber}/full-status` })
+    return this.restClient.get({ path: `/api/prisoners/${prisonerNumber}/full-status` })
   }
 
   async getCourtDateResults(prisonerNumber: string): Promise<CourtDateResults[]> {
-    return this.get<CourtDateResults[]>({
+    return this.restClient.get<CourtDateResults[]>({
       path: `/api/court-date-results/${prisonerNumber}`,
     })
   }
 
   async getIdentifiers(bookingId: number): Promise<OffenderIdentifier[]> {
-    return this.get<OffenderIdentifier[]>({
+    return this.restClient.get<OffenderIdentifier[]>({
       path: `/api/bookings/${bookingId}/identifiers`,
     })
   }
 
   async getSentenceSummary(prisonerNumber: string): Promise<SentenceSummary> {
-    return this.get<SentenceSummary>({
+    return this.restClient.get<SentenceSummary>({
       path: `/api/offenders/${prisonerNumber}/booking/latest/sentence-summary`,
     })
   }
 
   async getStaffRoles(staffId: number, agencyId: string): Promise<StaffRole[]> {
-    return this.get<StaffRole[]>({ path: `/api/staff/${staffId}/${agencyId}/roles` })
+    return this.restClient.get<StaffRole[]>({ path: `/api/staff/${staffId}/${agencyId}/roles` })
   }
 
   async getAgencyDetails(agencyId: string): Promise<AgencyLocationDetails | null> {
-    return this.get<AgencyLocationDetails>({
+    return this.restClient.get<AgencyLocationDetails>({
       path: `/api/agencies/${agencyId}?activeOnly=false`,
       ignore404: true,
     })
   }
 
   async getOffenderCellHistory(bookingId: number, params: object): Promise<OffenderCellHistory> {
-    return this.get<OffenderCellHistory>({
+    return this.restClient.get<OffenderCellHistory>({
       path: `/api/bookings/${bookingId}/cell-history?${mapToQueryString(params)}`,
     })
   }
 
   async getStaffDetails(staffId: string): Promise<StaffDetails> {
-    return this.get<StaffDetails>({ path: `/api/users/${staffId}` })
+    return this.restClient.get<StaffDetails>({ path: `/api/users/${staffId}` })
   }
 
   async getInmatesAtLocation(locationId: number, params: object): Promise<LocationsInmate[]> {
-    return this.get<LocationsInmate[]>({ path: `/api/locations/${locationId}/inmates?${mapToQueryString(params)}` })
+    return this.restClient.get<LocationsInmate[]>({
+      path: `/api/locations/${locationId}/inmates?${mapToQueryString(params)}`,
+    })
   }
 
   async getAlertTypes(): Promise<AlertType[]> {
-    return this.get<AlertType[]>({
+    return this.restClient.get<AlertType[]>({
       path: `/api/reference-domains/domains/ALERT?withSubCodes=true`,
       headers: { 'page-limit': '1000' },
     })
   }
 
   async createAlert(bookingId: number, alert: AlertForm): Promise<Alert> {
-    return (await this.post({ path: `/api/bookings/${bookingId}/alert`, data: alert })) as Alert
+    return (await this.restClient.post({
+      path: `/api/bookings/${bookingId}/alert`,
+      data: alert,
+    })) as Alert
   }
 
   async getCsraAssessment(bookingId: number, assessmentSeq: number): Promise<CsraAssessment> {
-    return this.get<CsraAssessment>({
+    return this.restClient.get<CsraAssessment>({
       path: `/api/offender-assessments/csra/${bookingId}/assessment/${assessmentSeq}`,
     })
   }
 
   async getCsraAssessmentsForPrisoner(prisonerNumber: string): Promise<CsraAssessment[]> {
-    return this.get<CsraAssessment[]>({
+    return this.restClient.get<CsraAssessment[]>({
       path: `/api/offender-assessments/csra/${prisonerNumber}`,
     })
   }
 
   async getTransactionHistory(prisonerNumber: string, params: object): Promise<Transaction[]> {
-    return this.get<Transaction[]>({
+    return this.restClient.get<Transaction[]>({
       path: `/api/offenders/${prisonerNumber}/transaction-history`,
       query: mapToQueryString(params),
     })
   }
 
   async getDamageObligations(prisonerNumber: string, status?: string): Promise<DamageObligationContainer> {
-    return this.get<DamageObligationContainer>({
+    return this.restClient.get<DamageObligationContainer>({
       path: `/api/offenders/${prisonerNumber}/damage-obligations`,
       query: mapToQueryString({ status: status || 'ACTIVE' }),
     })
   }
 
   async getScheduledEventsForThisWeek(bookingId: number): Promise<ScheduledEvent[]> {
-    return this.get<ScheduledEvent[]>({ path: `/api/bookings/${bookingId}/events/thisWeek` })
+    return this.restClient.get<ScheduledEvent[]>({ path: `/api/bookings/${bookingId}/events/thisWeek` })
   }
 
   async getScheduledEventsForNextWeek(bookingId: number): Promise<ScheduledEvent[]> {
-    return this.get<ScheduledEvent[]>({ path: `/api/bookings/${bookingId}/events/nextWeek` })
+    return this.restClient.get<ScheduledEvent[]>({ path: `/api/bookings/${bookingId}/events/nextWeek` })
   }
 
   async getMovements(
@@ -362,7 +368,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     movementTypes: MovementType[],
     latestOnly: boolean = true,
   ): Promise<Movement[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/movements/offenders`,
       query: mapToQueryString({ movementTypes, latestOnly }),
       data: prisonerNumbers,
@@ -370,19 +376,22 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getLocationsForAppointments(agencyId: string): Promise<Location[]> {
-    return this.get<Location[]>({ path: `/api/agencies/${agencyId}/locations?eventType=APP` })
+    return this.restClient.get<Location[]>({ path: `/api/agencies/${agencyId}/locations?eventType=APP` })
   }
 
   async getAppointmentTypes(): Promise<ReferenceCode[]> {
-    return this.get<ReferenceCode[]>({ path: '/api/reference-domains/scheduleReasons?eventType=APP' })
+    return this.restClient.get<ReferenceCode[]>({ path: '/api/reference-domains/scheduleReasons?eventType=APP' })
   }
 
   async getSentenceData(offenderNumbers: string[]): Promise<OffenderSentenceDetail[]> {
-    return (await this.post({ path: '/api/offender-sentences', data: offenderNumbers })) as OffenderSentenceDetail[]
+    return (await this.restClient.post({
+      path: '/api/offender-sentences',
+      data: offenderNumbers,
+    })) as OffenderSentenceDetail[]
   }
 
   async getCourtEvents(offenderNumbers: string[], agencyId: string, date: string): Promise<PrisonerSchedule[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/schedules/${agencyId}/courtEvents?date=${date}`,
       data: offenderNumbers,
     })) as PrisonerSchedule[]
@@ -394,7 +403,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     date: string,
     timeSlot?: TimeSlot,
   ): Promise<PrisonerSchedule[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/schedules/${agencyId}/visits`,
       query: mapToQueryString({ date, timeSlot }),
       data: offenderNumbers,
@@ -407,7 +416,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     date: string,
     timeSlot?: TimeSlot,
   ): Promise<PrisonerSchedule[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/schedules/${agencyId}/appointments`,
       query: mapToQueryString({ date, timeSlot }),
       data: offenderNumbers,
@@ -420,7 +429,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     date: string,
     timeSlot?: TimeSlot,
   ): Promise<PrisonerSchedule[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/schedules/${agencyId}/activities`,
       query: mapToQueryString({ date, timeSlot }),
       data: offenderNumbers,
@@ -428,14 +437,14 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getExternalTransfers(offenderNumbers: string[], agencyId: string, date: string): Promise<PrisonerSchedule[]> {
-    return (await this.post({
+    return (await this.restClient.post({
       path: `/api/schedules/${agencyId}/externalTransfers?date=${date}`,
       data: offenderNumbers,
     })) as PrisonerSchedule[]
   }
 
   async getLocation(locationId: number): Promise<Location> {
-    return this.get<Location>({ path: `/api/locations/${locationId}` })
+    return this.restClient.get<Location>({ path: `/api/locations/${locationId}` })
   }
 
   async getActivitiesAtLocation(
@@ -444,7 +453,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     timeSlot?: TimeSlot,
     includeSuspended = false,
   ): Promise<PrisonerSchedule[]> {
-    return this.get<PrisonerSchedule[]>({
+    return this.restClient.get<PrisonerSchedule[]>({
       path: `/api/schedules/locations/${locationId}/activities`,
       query: mapToQueryString({ date, timeSlot, includeSuspended }),
     })
@@ -457,7 +466,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     date: string,
     timeSlot?: TimeSlot,
   ): Promise<PrisonerSchedule[]> {
-    return this.get<PrisonerSchedule[]>({
+    return this.restClient.get<PrisonerSchedule[]>({
       path: `/api/schedules/${agencyId}/locations/${locationId}/usage/${usage}`,
       query: mapToQueryString({ date, timeSlot }),
     })

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -99,8 +99,8 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     return this.get<VisitSummary>({ path: `/api/bookings/${bookingId}/visits/summary` })
   }
 
-  async getVisitBalances(prisonerNumber: string): Promise<VisitBalances> {
-    return this.get<VisitBalances>({
+  async getVisitBalances(prisonerNumber: string): Promise<VisitBalances | null> {
+    return this.get<VisitBalances | null>({
       path: `/api/bookings/offenderNo/${prisonerNumber}/visit/balances`,
       ignore404: true,
     })

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -206,8 +206,9 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     }
   }
 
+  // NB: This can return 404 for released prisoners
   async getAddresses(prisonerNumber: string): Promise<Address[]> {
-    return this.restClient.get<Address[]>({ path: `/api/offenders/${prisonerNumber}/addresses` })
+    return this.restClient.get<Address[]>({ path: `/api/offenders/${prisonerNumber}/addresses`, ignore404: true })
   }
 
   async getAddressesForPerson(personId: number): Promise<Address[]> {

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -102,6 +102,7 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   async getVisitBalances(prisonerNumber: string): Promise<VisitBalances> {
     return this.get<VisitBalances>({
       path: `/api/bookings/offenderNo/${prisonerNumber}/visit/balances`,
+      ignore404: true,
     })
   }
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -21,7 +21,7 @@ interface PostRequest {
   path?: string
   headers?: Record<string, string>
   responseType?: string
-  data?: Record<string, unknown>
+  data?: object | string[]
   raw?: boolean
   query?: string
 }

--- a/server/services/overviewPageService.test.ts
+++ b/server/services/overviewPageService.test.ts
@@ -182,6 +182,28 @@ describe('OverviewPageService', () => {
   })
 
   describe('getMiniSummaryGroupA', () => {
+    describe('When visit balances returns 404', () => {
+      it('Displays no visit information', async () => {
+        const prisonerNumber = 'A1234BC'
+        const bookingId = 123456
+
+        prisonApiClient.getVisitBalances = jest.fn(async () => null)
+        const overviewPageService = overviewPageServiceConstruct()
+        const res = await overviewPageService.get(
+          'token',
+          { prisonerNumber, bookingId, prisonId: 'MDI' } as Prisoner,
+          1,
+          CaseLoadsDummyDataA,
+        )
+
+        expect(res.miniSummaryGroupA.length).toEqual(3)
+        const visitSummary = res.miniSummaryGroupA[2]
+        expect(visitSummary.data.bottomClass).toEqual('big')
+        expect(visitSummary.data.bottomContentLine1).toEqual('0')
+        expect(visitSummary.data.bottomContentLine3).toEqual('')
+      })
+    })
+
     it('should get the account, adjudication and visit summaries for the prisoner', async () => {
       const prisonerNumber = 'A1234BC'
       const bookingId = 123456

--- a/server/services/overviewPageService.ts
+++ b/server/services/overviewPageService.ts
@@ -367,9 +367,9 @@ export default class OverviewPageService {
     ])
 
     let privilegedVisitsDescription = ''
-    if (visitBalances.remainingPvo) {
+    if (visitBalances?.remainingPvo) {
       privilegedVisitsDescription = formatPrivilegedVisitsSummary(visitBalances.remainingPvo)
-    } else if (visitBalances.remainingVo) {
+    } else if (visitBalances?.remainingVo) {
       privilegedVisitsDescription = 'No privileged visits'
     }
 
@@ -408,9 +408,9 @@ export default class OverviewPageService {
       topContent: visitSummary.startDateTime ? formatDate(visitSummary.startDateTime, 'short') : 'None scheduled',
       topClass: visitSummary.startDateTime ? 'big' : 'small',
       bottomLabel: 'Remaining visits',
-      bottomContentLine1: visitBalances.remainingVo ? visitBalances.remainingVo : '0',
+      bottomContentLine1: visitBalances?.remainingVo ? visitBalances.remainingVo : '0',
       bottomContentLine3: privilegedVisitsDescription,
-      bottomClass: visitBalances.remainingVo ? 'small' : 'big',
+      bottomClass: visitBalances?.remainingVo ? 'small' : 'big',
       linkLabel: 'Visits details',
       linkHref: `${config.serviceUrls.digitalPrison}/prisoner/${prisonerNumber}/visits-details`,
     }

--- a/server/services/personalPageService.test.ts
+++ b/server/services/personalPageService.test.ts
@@ -270,6 +270,13 @@ describe('PersonalPageService', () => {
   })
 
   describe('Addresses', () => {
+    it('Handles the API returning 404 for addresses', async () => {
+      prisonApiClient.getAddresses = jest.fn(async () => null)
+      const { addresses, addressSummary } = await constructService().get('token', PrisonerMockDataA)
+      expect(addresses).toBe(undefined)
+      expect(addressSummary).toEqual([])
+    })
+
     it('Maps the data from the API for the primary address', async () => {
       const { addresses, addressSummary } = await constructService().get('token', PrisonerMockDataA)
       const expectedAddress = mockAddresses[0]


### PR DESCRIPTION
Following on from #327 , this is another difference we have between other apps that could be causing memory issues.

Additionally, this has been hiding issues for a while where we're accidentally swallowing 500 errors, removing this should help alleviate that. However as some endpoints _do_ return 404s, we need to catch those ones and ignore them if it's approproate