### PR TITLE
NON-305: Always show links to non-associations in overview page

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -26,7 +26,6 @@ MANAGE_A_WARRANT_FOLDER_UI_URL=http://localhost:9091/manageawarrant
 PATHFINDER_UI_URL=http://localhost:9091/pathfinderui
 MANAGE_SOC_CASES_UI_URL=http://localhost:9091/managesoccasesui
 NON_ASSOCIATIONS_UI_URL=http://localhost:9091/nonassociationsui
-NON_ASSOCIATIONS_PRISONS=MDI,LGI,FNI,ISI,RSI
 MANAGE_ADJUDICATIONS_API_URL=http://localhost:9091/adjudications
 CALCULATE_RELEASE_DATES_UI_URL=http://localhost:9091/calculateRelease
 PRISONER_PROFILE_DELIUS_API_URL=http://localhost:9091/delius

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -39,7 +39,6 @@ generic-service:
     FEEDBACK_DISABLED_PRISONS: "AGI,DNI,FNI,HDI,HLI,HMI,LEI,LHI,MDI,NHI,RSI,WDI,WEI,WYI"
     ENVIRONMENT_NAME: "DEV"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api-dev.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities-dev.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -38,7 +38,6 @@ generic-service:
     FEEDBACK_DISABLED_PRISONS: "AGI,DNI,FNI,HDI,HLI,HMI,LEI,LHI,MDI,NHI,RSI,WDI,WEI,WYI"
     ENVIRONMENT_NAME: "PRE-PRODUCTION"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api-preprod.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities-preprod.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "RSI"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -41,7 +41,6 @@ generic-service:
     NON_ASSOCIATIONS_UI_URL: "https://non-associations.hmpps.service.justice.gov.uk"
     FEEDBACK_DISABLED_PRISONS: "AGI,DNI,FNI,HDI,HLI,HMI,LEI,LHI,MDI,NHI,RSI,WDI,WEI,WYI"
     NEURODIVERSITY_ENABLED_PRISONS: "BLI,NHI,LII,SLI"
-    NON_ASSOCIATIONS_PRISONS: "FNI,ISI,LGI,RSI"
     HMPPS_NON_ASSOCIATIONS_API_URL: "https://non-associations-api.hmpps.service.justice.gov.uk"
     ACTIVITIES_URL: "https://activities.prison.service.justice.gov.uk/activities"
     ACTIVITIES_ENABLED_PRISONS: "RSI"

--- a/integration_tests/e2e/overviewPage.cy.ts
+++ b/integration_tests/e2e/overviewPage.cy.ts
@@ -293,6 +293,11 @@ context('Overview Page', () => {
         overviewPage.alertsSummary().panel().should('exist')
         overviewPage.alertsSummary().alertCount().should('have.text', '80')
         overviewPage.alertsSummary().nonAssociationCount().should('have.text', '2')
+        overviewPage.alertsSummary().nonAssociationsLink().should('have.text', 'Non-associations')
+        overviewPage
+          .alertsSummary()
+          .nonAssociationsLink()
+          .should('have.attr', 'href', 'http://localhost:9091/nonassociationsui/prisoner/G6123VU/non-associations')
       })
     })
   })

--- a/integration_tests/pages/overviewPage.ts
+++ b/integration_tests/pages/overviewPage.ts
@@ -162,5 +162,7 @@ export default class OverviewPage extends Page {
     alertCount: (): PageElement => this.alertsSummary().panel().get('[data-qa=overview-active-alerts]'),
     nonAssociationCount: (): PageElement =>
       this.alertsSummary().panel().get('[data-qa=overview-non-association-count]'),
+    nonAssociationsLink: (): PageElement =>
+      this.alertsSummary().panel().get('[data-qa=overview-non-associations-link] a'),
   })
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -203,7 +203,6 @@ export default {
   feedbackDisabledPrisons: get('FEEDBACK_DISABLED_PRISONS', [], requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   neurodiversityEnabledPrisons: process.env.NEURODIVERSITY_ENABLED_PRISONS || [],
-  nonAssociationsPrisons: process.env.NON_ASSOCIATIONS_PRISONS?.split(',') || [],
   activitiesEnabledPrisons: get('ACTIVITIES_ENABLED_PRISONS', [], requiredInProduction),
   appointmentsEnabledPrisons: get('APPOINTMENTS_ENABLED_PRISONS', [], requiredInProduction),
   useOfForceDisabledPrisons: get('USE_OF_FORCE_DISABLED_PRISONS', [], requiredInProduction),

--- a/server/interfaces/overviewPage.ts
+++ b/server/interfaces/overviewPage.ts
@@ -29,7 +29,6 @@ export interface OverviewNonAssociation {
 export interface AlertsSummary {
   activeAlertCount: number
   nonAssociationsCount: number
-  showNonAssociationsLink: boolean
   nonAssociationsUrl: string
 }
 

--- a/server/services/overviewPageService.test.ts
+++ b/server/services/overviewPageService.test.ts
@@ -874,7 +874,6 @@ describe('OverviewPageService', () => {
         activeAlertCount: 1,
         nonAssociationsCount: 2,
         nonAssociationsUrl: `${config.serviceUrls.nonAssociations}/prisoner/G6123VU/non-associations`,
-        showNonAssociationsLink: false,
       })
     })
 
@@ -885,43 +884,6 @@ describe('OverviewPageService', () => {
         activeAlertCount: 1,
         nonAssociationsCount: 2,
         nonAssociationsUrl: `${config.serviceUrls.nonAssociations}/prisoner/G6123VU/non-associations`,
-        showNonAssociationsLink: false,
-      })
-    })
-
-    describe('Link to non-associations', () => {
-      describe('When non-associations is enabled for private beta', () => {
-        beforeEach(() => {
-          config.nonAssociationsPrisons = ['BAI', 'MDI']
-        })
-
-        it('should show non-associations link', async () => {
-          const overviewPageService = overviewPageServiceConstruct()
-          const res = await overviewPageService.get('token', PrisonerMockDataA, 1, CaseLoadsDummyDataB, [])
-          expect(res.alertsSummary).toEqual({
-            activeAlertCount: 1,
-            nonAssociationsCount: 2,
-            nonAssociationsUrl: `${config.serviceUrls.nonAssociations}/prisoner/G6123VU/non-associations`,
-            showNonAssociationsLink: true,
-          })
-        })
-      })
-
-      describe('When non-associations is disabled for private beta', () => {
-        beforeEach(() => {
-          config.nonAssociationsPrisons = ['MDI']
-        })
-
-        it('should show non-associations link', async () => {
-          const overviewPageService = overviewPageServiceConstruct()
-          const res = await overviewPageService.get('token', PrisonerMockDataA, 1, CaseLoadsDummyDataB, [])
-          expect(res.alertsSummary).toEqual({
-            activeAlertCount: 1,
-            nonAssociationsCount: 2,
-            nonAssociationsUrl: `${config.serviceUrls.nonAssociations}/prisoner/G6123VU/non-associations`,
-            showNonAssociationsLink: false,
-          })
-        })
       })
     })
   })

--- a/server/services/overviewPageService.ts
+++ b/server/services/overviewPageService.ts
@@ -17,7 +17,6 @@ import {
   formatPrivilegedVisitsSummary,
   getNamesFromString,
   neurodiversityEnabled,
-  nonAssociationsEnabled,
   prisonerBelongsToUsersCaseLoad,
   userHasRoles,
 } from '../utils/utils'
@@ -162,7 +161,7 @@ export default class OverviewPageService {
       offencesOverview,
       prisonName: prisonerData.prisonName,
       staffRoles: staffRoles.map(role => role.role),
-      alertsSummary: this.getAlertsSummary(inmateDetail, nonAssociations, userCaseLoads),
+      alertsSummary: this.getAlertsSummary(inmateDetail, nonAssociations),
     }
   }
 
@@ -557,14 +556,11 @@ export default class OverviewPageService {
   private getAlertsSummary(
     { activeAlertCount, offenderNo }: InmateDetail,
     nonAssociations: OverviewNonAssociation[],
-    userCaseloads: CaseLoad[],
   ): AlertsSummary {
-    const activeCaseload = userCaseloads.find(caseload => caseload.currentlyActive)
     const nonAssociationsCount = nonAssociations.length
-    const showNonAssociationsLink = nonAssociationsEnabled(activeCaseload?.caseLoadId)
     const nonAssociationsUrl = `${config.serviceUrls.nonAssociations}/prisoner/${offenderNo}/non-associations`
 
-    return { activeAlertCount, nonAssociationsCount, showNonAssociationsLink, nonAssociationsUrl }
+    return { activeAlertCount, nonAssociationsCount, nonAssociationsUrl }
   }
 
   private async getSchedule(prisonerData: Prisoner, prisonApiClient: PrisonApiClient): Promise<OverviewSchedule> {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -470,10 +470,6 @@ export const neurodiversityEnabled = (agencyId: string): boolean => {
   return isEnabled
 }
 
-export const nonAssociationsEnabled = (agencyId: string): boolean => {
-  return config.nonAssociationsPrisons?.includes(agencyId)
-}
-
 export const stripAgencyPrefix = (location: string, agency: string): string => {
   const parts = location && location.split('-')
   if (parts && parts.length > 0) {

--- a/server/views/partials/overviewPage/alerts/alerts.njk
+++ b/server/views/partials/overviewPage/alerts/alerts.njk
@@ -14,9 +14,7 @@
         <div class="govuk-!-padding-top-3">
             <dt class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">Non-associations in {{ prisonName }}</dt>
             <dd class="govuk-!-margin-left-0 govuk-!-margin-bottom-2" data-qa="overview-non-association-count">{{ alertsSummary.nonAssociationsCount }}</dd>
-            {% if alertsSummary.showNonAssociationsLink %}
-                <dd class="govuk-!-margin-left-0"><a href="{{ alertsSummary.nonAssociationsUrl }}" class="govuk-link govuk-link--no-visited-state">Non-associations</a></dd>
-            {% endif %}
+            <dd class="govuk-!-margin-left-0" data-qa="overview-non-associations-link"><a href="{{ alertsSummary.nonAssociationsUrl }}" class="govuk-link govuk-link--no-visited-state">Non-associations</a></dd>
         </div>
     </div>
 </dl>


### PR DESCRIPTION
The link to prisoner's non-associations (in the Non-associations service) will be shown always.

Previously we had a short list of prisons that could see these links but we want to show these links all the time now as there is no harm in doing so.