### PR TITLE
CDPS-401 - update to 1600% for requests (80% of limit)

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-prisoner-profile/values.yaml
 
 generic-service:
@@ -14,7 +13,7 @@ generic-service:
     enabled: true
     minReplicas: 4
     maxReplicas: 8
-    targetCPUUtilizationPercentage: 95
+    targetCPUUtilizationPercentage: 1600
 
   env:
     INGRESS_URL: "https://prisoner.digital.prison.service.justice.gov.uk"


### PR DESCRIPTION
Based on https://sysdig.com/blog/kubernetes-limits-requests/ we're currently running a bare minimum request size for the containers for the profile. This is causing a few issues for the Horizontal Pod Autoscale settings. `targetCPUUtilizationPercentage` is based on the minimum CPU request size so the scaling needs to take into account the limit.  
By making the calculation `targetRequest% = targetValue% (range 0-100) * (limit/request)%` should give what's needed - this can be more than 100%.

we've done 2 things:

- upped the `limitRange` settings for minimum `defaultRequest` size to `100m` CPU (0.1 vCPU) - in  PR:https://github.com/ministryofjustice/cloud-platform-environments/pull/17635 
- set the `targetCPUUtilizationPercentage` HPA to 1600% (which is 80% of the total CPU limit).

We'll look to make the same sort of changes to the homepage and the MFE service soon after.
