### PR TITLE
CDPS-571 -  🔒 add modsec rules. 

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-prisoner-profile/values.yaml
 
 generic-service:
@@ -11,6 +10,8 @@ generic-service:
     modsecurity_snippet: |
       SecRuleEngine On
       SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   env:
     INGRESS_URL: "https://prisoner-dev.digital.prison.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,8 @@ generic-service:
     modsecurity_snippet: |
       SecRuleEngine On
       SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   env:
     INGRESS_URL: "https://prisoner-preprod.digital.prison.service.justice.gov.uk"
@@ -59,10 +61,10 @@ generic-service:
     sscl-newcastle: 62.172.79.105/32
     sscl-newport: 217.38.237.212/32
     groups:
-      - internal
-      - prisons
-      - private_prisons
-      - police
+    - internal
+    - prisons
+    - private_prisons
+    - police
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-prisoner-profile-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,8 @@ generic-service:
     modsecurity_snippet: |
       SecRuleEngine On
       SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   autoscaling:
     enabled: true
@@ -62,10 +64,10 @@ generic-service:
     sscl-newcastle: 62.172.79.105/32
     sscl-newport: 217.38.237.212/32
     groups:
-      - internal
-      - prisons
-      - private_prisons
-      - police
+    - internal
+    - prisons
+    - private_prisons
+    - police
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-prisoner-profile-prod


### PR DESCRIPTION
Modsec is firing 406 errors for a number of rules. We need to let the service to run in these scenarios, potentially due to false positives. 

we'll investigate why this is triggering in a later ticket.