### PR TITLE
Renamed cookie to match project name.

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -14,6 +14,7 @@ export default function setUpWebSession(): Router {
   router.use(
     session({
       store: new RedisStore({ client }),
+      name: 'hmpps-prisoner-profile',
       cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,
       resave: false, // redis implements touch so shouldn't need this


### PR DESCRIPTION
Explicitly name cookie in Prisoner Profile rather than relying on express-session default connect.sid.