### PR TITLE
Tag dev modsecurity default action with useful searchable items V1

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,7 @@ generic-service:
     modsecurity_github_team: "connect-dps"
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=connect-dps,tag:namespace=hmpps-prisoner-profile-dev"
     # SecRuleRemoveById 949110
     # SecRuleRemoveById 942440
     # SecRuleRemoveById 920300

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,10 +8,10 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_github_team: "connect-dps"
     modsecurity_snippet: |
-      SecRuleEngine On
-      SecRuleRemoveById 949110
-      SecRuleRemoveById 942440
-      SecRuleRemoveById 920300
+      SecRuleEngine DetectionOnly
+    # SecRuleRemoveById 949110
+    # SecRuleRemoveById 942440
+    # SecRuleRemoveById 920300
 
   env:
     ENVIRONMENT_NAME: "DEV"


### PR DESCRIPTION
We've added tagging to dev to allow us to search for `github_team=connect-dps` and `namespace=hmpps-prisoner-profile-dev` - this should help narrow down the logs in `DetectionOnly` Mode in modesecurity