### PR TITLE
Add Sec Default rule with appropriate tagging. V1.1

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,7 @@ generic-service:
     modsecurity_github_team: "connect-dps"
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=connect-dps,tag:namespace=hmpps-prisoner-profile-dev"
     # SecRuleRemoveById 949110
     # SecRuleRemoveById 942440
     # SecRuleRemoveById 920300


### PR DESCRIPTION
We've added tagging to dev to allow us to search for `github_team=connect-dps` and `namespace=hmpps-prisoner-profile-dev` 
- this should help narrow down the logs in `DetectionOnly` mode in modsecurity
Clean branch used.