### PR TITLE
V2 - using commented out default from generic service.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,14 +6,27 @@ generic-service:
   ingress:
     host: prisoner-dev.digital.prison.service.justice.gov.uk
     modsecurity_enabled: true
+    modsecurity_audit_enabled: true
     modsecurity_github_team: "connect-dps"
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
-      SecDefaultAction "phase:2,pass,log,tag:github_team=connect-dps,tag:namespace=hmpps-prisoner-profile-dev"
-    # SecRuleRemoveById 949110
-    # SecRuleRemoveById 942440
-    # SecRuleRemoveById 920300
-
+      {{ if .Values.ingress.modsecurity_audit_enabled -}}
+      SecAuditEngine RelevantOnly
+      SecAuditLog /var/log/nginx/error.log
+      SecAuditLogType Serial
+      {{ end -}}
+      {{if .Values.ingress.modsecurity_github_team -}}
+      SecDefaultAction "phase:2,pass,log,tag:github_team={{ .Values.ingress.modsecurity_github_team }},tag:namespace={{  .Release.Namespace  }}"
+      {{ end -}}
+    #  SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+    #  SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+    #  SecAction \
+    #    "id:900000,\
+    #     phase:1,\
+    #     nolog,\
+    #     pass,\
+    #     t:none,\
+    #     setvar:tx.paranoia_level=2"
   env:
     ENVIRONMENT_NAME: "DEV"
     INGRESS_URL: "https://prisoner-dev.digital.prison.service.justice.gov.uk"


### PR DESCRIPTION
- adding some example modsecurity settings - part back in from generic service chart - was commented out here:
https://github.com/ministryofjustice/hmpps-helm-charts/commit/4ce3afdf951a6e6b433a67cd39336a4a91901704
- switch on audit.