### PR TITLE
RR-575 - Add new REST API client for the Education And Work Plan API (PLP API)

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -30,6 +30,7 @@ MANAGE_ADJUDICATIONS_API_URL=http://localhost:9091/adjudications
 CALCULATE_RELEASE_DATES_UI_URL=http://localhost:9091/calculateRelease
 PRISONER_PROFILE_DELIUS_API_URL=http://localhost:9091/delius
 COMPLEXITY_OF_NEED_API_URL=http://localhost:9091/complexity
+EDUCATION_AND_WORK_PLAN_API_URL=http://localhost:9091/plpApi
 
 DPS_HOME_PAGE_URL=http://localhost:9091/dpshomepage
 ADJUDICATIONS_UI_URL=http://localhost:3000/adjudications

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -55,6 +55,7 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api-dev.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk"
 
     # Feature flags
     AUDIT_ENABLED: "true"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -54,6 +54,7 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api-preprod.prison.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api-preprod.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk"
 
     # Feature flags
     AUDIT_ENABLED: "true"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -61,6 +61,7 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search.prison.service.justice.gov.uk"
     PRISON_API_URL: "https://api.prison.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api.hmpps.service.justice.gov.uk"
 
     # Feature flags
     AUDIT_ENABLED: "true"

--- a/server/config.ts
+++ b/server/config.ts
@@ -206,6 +206,14 @@ export default {
       },
       agent: new AgentConfig(Number(get('COMPLEXITY_OF_NEED_API_TIMEOUT_DEADLINE', 5000))),
     },
+    educationAndWorkPlanApi: {
+      url: get('EDUCATION_AND_WORK_PLAN_API_URL', 'http://localhost:8082', requiredInProduction),
+      timeout: {
+        response: Number(get('EDUCATION_AND_WORK_PLAN_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('EDUCATION_AND_WORK_PLAN_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(),
+    },
   },
   serviceUrls: {
     offenderCategorisation: get('OFFENDER_CATEGORISATION_UI_URL', 'http://localhost:3001', requiredInProduction),

--- a/server/data/educationAndWorkPlanApiClient.test.ts
+++ b/server/data/educationAndWorkPlanApiClient.test.ts
@@ -1,0 +1,58 @@
+import nock from 'nock'
+import config from '../config'
+import EducationAndWorkPlanApiRestClient from './educationAndWorkPlanApiClient'
+import { aValidActionPlanResponseWithOneGoal } from './localMockData/actionPlanResponse'
+
+describe('educationAndWorkPlanApiClient', () => {
+  const systemToken = 'a-system-token'
+  const educationAndWorkPlanClient = new EducationAndWorkPlanApiRestClient(systemToken)
+
+  let educationAndWorkPlanApi: nock.Scope
+
+  beforeEach(() => {
+    educationAndWorkPlanApi = nock(config.apis.educationAndWorkPlanApi.url)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('getPrisonerActionPlan', () => {
+    it('should get Action Plan', async () => {
+      // Given
+      const prisonerNumber = 'A1234BC'
+
+      const expectedActionPlanResponse = aValidActionPlanResponseWithOneGoal()
+      educationAndWorkPlanApi.get(`/action-plans/${prisonerNumber}`).reply(200, expectedActionPlanResponse)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getPrisonerActionPlan(prisonerNumber)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedActionPlanResponse)
+    })
+
+    it('should not get Action Plan given API returns error response', async () => {
+      // Given
+      const prisonerNumber = 'A1234BC'
+
+      const expectedResponseBody = {
+        status: 501,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi.get(`/action-plans/${prisonerNumber}`).reply(501, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.getPrisonerActionPlan(prisonerNumber)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(501)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+})

--- a/server/data/educationAndWorkPlanApiClient.ts
+++ b/server/data/educationAndWorkPlanApiClient.ts
@@ -1,0 +1,21 @@
+import { EducationAndWorkPlanApiClient } from './interfaces/educationAndWorkPlanApiClient'
+import RestClient from './restClient'
+import config from '../config'
+import { ActionPlanResponse } from '../interfaces/educationAndWorkPlanApi/actionPlanResponse'
+
+/**
+ * REST API client implementation of [EducationAndWorkPlanApiClient] (aka. the PLP API Client)
+ */
+export default class EducationAndWorkPlanApiRestClient implements EducationAndWorkPlanApiClient {
+  private readonly restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('Education And Work Plan API', config.apis.educationAndWorkPlanApi, token)
+  }
+
+  getPrisonerActionPlan(prisonerNumber: string): Promise<ActionPlanResponse> {
+    return this.restClient.get<ActionPlanResponse>({
+      path: `/action-plans/${prisonerNumber}`,
+    })
+  }
+}

--- a/server/data/interfaces/educationAndWorkPlanApiClient.ts
+++ b/server/data/interfaces/educationAndWorkPlanApiClient.ts
@@ -1,0 +1,8 @@
+import { ActionPlanResponse } from '../../interfaces/educationAndWorkPlanApi/actionPlanResponse'
+
+/**
+ * Interface defining the REST API operations of the Education And Work Plan API (aka. the PLP API)
+ */
+export interface EducationAndWorkPlanApiClient {
+  getPrisonerActionPlan(prisonerNumber: string): Promise<ActionPlanResponse>
+}

--- a/server/data/localMockData/actionPlanResponse.ts
+++ b/server/data/localMockData/actionPlanResponse.ts
@@ -1,0 +1,49 @@
+import { ActionPlanResponse } from '../../interfaces/educationAndWorkPlanApi/actionPlanResponse'
+import { GoalResponse } from '../../interfaces/educationAndWorkPlanApi/goalResponse'
+import { StepResponse } from '../../interfaces/educationAndWorkPlanApi/stepResponse'
+
+const aValidActionPlanResponseWithOneGoal = (): ActionPlanResponse => {
+  return {
+    reference: 'a20912ab-4dae-4aa4-8bc5-32319da8fceb',
+    prisonNumber: 'A1234BC',
+    goals: [aValidGoalResponse()],
+  }
+}
+const aValidGoalResponse = (): GoalResponse => {
+  return {
+    goalReference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
+    title: 'Learn Spanish',
+    status: 'ACTIVE',
+    steps: [aValidFirstStepResponse(), aValidSecondStepResponse()],
+    createdBy: 'asmith_gen',
+    createdByDisplayName: 'Alex Smith',
+    createdAt: '2023-01-16',
+    createdAtPrison: 'MDI',
+    updatedBy: 'asmith_gen',
+    updatedByDisplayName: 'Alex Smith',
+    updatedAt: '2023-09-23',
+    updatedAtPrison: 'MDI',
+    targetCompletionDate: '2024-02-29',
+    notes: 'Prisoner is not good at listening',
+  }
+}
+
+const aValidFirstStepResponse = (): StepResponse => {
+  return {
+    stepReference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
+    title: 'Book Spanish course',
+    status: 'ACTIVE',
+    sequenceNumber: 1,
+  }
+}
+
+const aValidSecondStepResponse = (): StepResponse => {
+  return {
+    stepReference: 'dc817ce8-2b2e-4282-96b2-b9a1d831fc56',
+    title: 'Complete Spanish course',
+    status: 'NOT_STARTED',
+    sequenceNumber: 2,
+  }
+}
+
+export { aValidActionPlanResponseWithOneGoal, aValidGoalResponse }

--- a/server/interfaces/educationAndWorkPlanApi/actionPlanResponse.ts
+++ b/server/interfaces/educationAndWorkPlanApi/actionPlanResponse.ts
@@ -1,0 +1,29 @@
+import { GoalResponse } from './goalResponse'
+
+/**
+ * ActionPlanResponse type - manually implemented here by copying it from the Education And Work Plan API swagger spec:
+ * https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk/v3/api-docs
+ */
+export interface ActionPlanResponse {
+  /**
+   * Format: uuid
+   * @description The Action Plan's unique reference
+   * @example 814ade0a-a3b2-46a3-862f-79211ba13f7b
+   */
+  reference: string
+  /**
+   * @description The ID of the prisoner
+   * @example A1234BC
+   */
+  prisonNumber: string
+  /**
+   * @description A List of at least one or more Goals.
+   * @example null
+   */
+  goals: Array<GoalResponse>
+  /**
+   * Format: date
+   * @description An optional ISO-8601 date representing when the Action Plan is up for review.
+   */
+  reviewDate?: string
+}

--- a/server/interfaces/educationAndWorkPlanApi/goalResponse.ts
+++ b/server/interfaces/educationAndWorkPlanApi/goalResponse.ts
@@ -1,0 +1,81 @@
+import { StepResponse } from './stepResponse'
+
+/**
+ * GoalResponse type - manually implemented here by copying it from the Education And Work Plan API swagger spec:
+ * https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk/v3/api-docs
+ */
+export interface GoalResponse {
+  /**
+   * Format: uuid
+   * @description The Goal's unique reference
+   * @example c88a6c48-97e2-4c04-93b5-98619966447b
+   */
+  goalReference: string
+  /**
+   * @description A title explaining the aim of the goal.
+   * @example Improve communication skills
+   */
+  title: string
+  /**
+   * Format: date
+   * @description An optional ISO-8601 date representing the target completion date of the Goal.
+   */
+  targetCompletionDate: string
+  /**
+   * @example null
+   * @enum {string}
+   */
+  status: 'ACTIVE' | 'COMPLETED' | 'ARCHIVED'
+  /**
+   * @description A List of at least one Step.
+   * @example null
+   */
+  steps: Array<StepResponse>
+  /**
+   * @description The DPS username of the person who created the goal.
+   * @example asmith_gen
+   */
+  createdBy: string
+  /**
+   * @description The display name of the person who created the goal.
+   * @example Alex Smith
+   */
+  createdByDisplayName: string
+  /**
+   * Format: date-time
+   * @description An ISO-8601 timestamp representing when the Goal was created.
+   * @example 2023-06-19T09:39:44Z
+   */
+  createdAt: string
+  /**
+   * @description The identifier of the prison that the prisoner was resident at when the Goal was created.
+   * @example BXI
+   */
+  createdAtPrison: string
+  /**
+   * @description The DPS username of the person who last updated the goal.
+   * @example asmith_gen
+   */
+  updatedBy: string
+  /**
+   * @description The display name of the person who last updated the goal.
+   * @example Alex Smith
+   */
+  updatedByDisplayName: string
+  /**
+   * Format: date-time
+   * @description An ISO-8601 timestamp representing when the Goal was last updated. This will be the same as the created date if it has not yet been updated.
+   * @example 2023-06-19T09:39:44Z
+   */
+  updatedAt: string
+  /**
+   * @description The identifier of the prison that the prisoner was resident at when the Goal was updated.
+   * @example BXI
+   */
+  updatedAtPrison: string
+  /**
+   * @description Some additional notes related to the Goal.
+   * @example Pay close attention to Peter's behaviour.
+   */
+  notes?: string
+}

--- a/server/interfaces/educationAndWorkPlanApi/stepResponse.ts
+++ b/server/interfaces/educationAndWorkPlanApi/stepResponse.ts
@@ -1,0 +1,28 @@
+/**
+ * StepResponse type - manually implemented here by copying it from the Education And Work Plan API swagger spec:
+ * https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk/v3/api-docs
+ */
+export interface StepResponse {
+  /**
+   * Format: uuid
+   * @description A unique reference for the Step
+   * @example d38a6c41-13d1-1d05-13c2-24619966119b
+   */
+  stepReference: string
+  /**
+   * @description A title describing the step
+   * @example Book communication skills course
+   */
+  title: string
+  /**
+   * @example null
+   * @enum {string}
+   */
+  status: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE'
+  /**
+   * Format: int32
+   * @description The number (position) of the Step within the overall Goal.
+   * @example 1
+   */
+  sequenceNumber: number
+}


### PR DESCRIPTION
This PR adds the new REST API client for the Education And Work Plan API (PLP API)

Functionally it is equivalent to what we've done in PLP UI and CIAG UI, but the patterns are slightly different. I've adopted and followed the patterns already established in this code base, rather than trying to do something new. Specifically:

* I have not imported the swagger spec to generate the types. Instead I have manually implemented them in `server/interfaces/educationAndWorkPlanApi` which is consistent with how/where all the other API response types are defined.
* I have defined and implemented an interface for the REST API client class. We've not bothered with that in PLP & CIAG, but all the other client classes in this code base have one, so I've followed suit.
* What we would know and love as a "test data builder" is not in the `testSupport` directory, but instead is in `server/data/localMockData`. But its the same idea; just in a different directory 🤷‍♂️ 

Other than that, this should look pretty familiar with what we've done in PLP UI and CIAG UI in respect of REST API client classes.

At the moment it's not used by anything. There is no service code calling this, so whilst the URLs in the helm deployments are setup correctly, I've not setup the secrets yet for the system token to have the correct role. That will come soon 👍 

But as it stands there is no risk that the PLP API will be called because there is nothing that is calling/using this new REST API class.