### PR TITLE
RR-575 - Add new PLP service with implementation for Education & Work Plan API

### DIFF
--- a/server/data/localMockData/actionPlanResponse.ts
+++ b/server/data/localMockData/actionPlanResponse.ts
@@ -2,26 +2,40 @@ import { ActionPlanResponse } from '../../interfaces/educationAndWorkPlanApi/act
 import { GoalResponse } from '../../interfaces/educationAndWorkPlanApi/goalResponse'
 import { StepResponse } from '../../interfaces/educationAndWorkPlanApi/stepResponse'
 
-const aValidActionPlanResponseWithOneGoal = (): ActionPlanResponse => {
+const aValidActionPlanResponse = (options?: {
+  reference?: string
+  prisonNumber?: string
+  goals?: Array<GoalResponse>
+}): ActionPlanResponse => {
   return {
-    reference: 'a20912ab-4dae-4aa4-8bc5-32319da8fceb',
-    prisonNumber: 'A1234BC',
-    goals: [aValidGoalResponse()],
+    reference: options?.reference || 'a20912ab-4dae-4aa4-8bc5-32319da8fceb',
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    goals: options?.goals || [aValidGoalResponse()],
   }
 }
-const aValidGoalResponse = (): GoalResponse => {
+
+const aValidActionPlanResponseWithOneGoal = (): ActionPlanResponse => {
+  return aValidActionPlanResponse({ goals: [aValidGoalResponse()] })
+}
+
+const aValidGoalResponse = (options?: {
+  reference?: string
+  title?: string
+  createdAt?: string
+  updatedAt?: string
+}): GoalResponse => {
   return {
-    goalReference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
-    title: 'Learn Spanish',
+    goalReference: options?.reference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
+    title: options?.title || 'Learn Spanish',
     status: 'ACTIVE',
     steps: [aValidFirstStepResponse(), aValidSecondStepResponse()],
     createdBy: 'asmith_gen',
     createdByDisplayName: 'Alex Smith',
-    createdAt: '2023-01-16',
+    createdAt: options?.createdAt || '2023-01-16T09:14:43.158Z',
     createdAtPrison: 'MDI',
     updatedBy: 'asmith_gen',
     updatedByDisplayName: 'Alex Smith',
-    updatedAt: '2023-09-23',
+    updatedAt: options?.updatedAt || '2023-09-23T14:43:02.094Z',
     updatedAtPrison: 'MDI',
     targetCompletionDate: '2024-02-29',
     notes: 'Prisoner is not good at listening',
@@ -46,4 +60,4 @@ const aValidSecondStepResponse = (): StepResponse => {
   }
 }
 
-export { aValidActionPlanResponseWithOneGoal, aValidGoalResponse }
+export { aValidActionPlanResponse, aValidActionPlanResponseWithOneGoal, aValidGoalResponse }

--- a/server/data/localMockData/personalLearningPlanActionPlan.ts
+++ b/server/data/localMockData/personalLearningPlanActionPlan.ts
@@ -1,0 +1,28 @@
+import { PersonalLearningPlanActionPlan, PersonalLearningPlanGoal } from '../../interfaces/personalLearningPlanGoals'
+
+const aValidPersonalLearningPlanActionPlan = (options?: {
+  prisonerNumber?: string
+  goals?: Array<PersonalLearningPlanGoal>
+}): PersonalLearningPlanActionPlan => {
+  return {
+    prisonerNumber: options?.prisonerNumber || 'A1234BC',
+    goals: options?.goals || [aValidPersonalLearningPlanGoal()],
+    problemRetrievingData: false,
+  }
+}
+
+const aValidPersonalLearningPlanGoal = (options?: {
+  reference?: string
+  title?: string
+  createdAt?: Date
+  updatedAt?: Date
+}): PersonalLearningPlanGoal => {
+  return {
+    reference: options?.reference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
+    title: options?.title || 'Learn Spanish',
+    createdAt: options?.createdAt || new Date('2023-01-16T09:14:43.158Z'),
+    updatedAt: options?.updatedAt || new Date('2023-09-23T14:43:02.094Z'),
+  }
+}
+
+export { aValidPersonalLearningPlanActionPlan, aValidPersonalLearningPlanGoal }

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
@@ -1,0 +1,52 @@
+import toPersonalLearningPlanActionPlan from './personalLearningPlanActionPlanMapper'
+import { aValidActionPlanResponse, aValidGoalResponse } from '../../data/localMockData/actionPlanResponse'
+import { PersonalLearningPlanActionPlan } from '../personalLearningPlanGoals'
+
+describe('personalLearningPlanActionPlanMapper', () => {
+  it('should map ActionPlanResponse to a PersonalLearningPlanActionPlan', () => {
+    // Given
+    const apiActionPlanResponse = aValidActionPlanResponse({
+      reference: 'a20912ab-4dae-4aa4-8bc5-32319da8fceb',
+      prisonNumber: 'A1234BC',
+      goals: [
+        aValidGoalResponse({
+          title: 'Learn French',
+          reference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
+          createdAt: '2023-01-16T09:14:43.158Z',
+          updatedAt: '2023-09-23T14:43:02.094Z',
+        }),
+        aValidGoalResponse({
+          title: 'Learn basic carpentry',
+          reference: '30b8abe1-736f-426d-87a7-0e1a7f2f63ab',
+          createdAt: '2023-03-20T10:24:03.651Z',
+          updatedAt: '2023-07-01T11:14:43.017Z',
+        }),
+      ],
+    })
+
+    const expected: PersonalLearningPlanActionPlan = {
+      prisonerNumber: 'A1234BC',
+      goals: [
+        {
+          reference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
+          title: 'Learn French',
+          createdAt: new Date('2023-01-16T09:14:43.158Z'),
+          updatedAt: new Date('2023-09-23T14:43:02.094Z'),
+        },
+        {
+          reference: '30b8abe1-736f-426d-87a7-0e1a7f2f63ab',
+          title: 'Learn basic carpentry',
+          createdAt: new Date('2023-03-20T10:24:03.651Z'),
+          updatedAt: new Date('2023-07-01T11:14:43.017Z'),
+        },
+      ],
+      problemRetrievingData: false,
+    }
+
+    // When
+    const actual = toPersonalLearningPlanActionPlan(apiActionPlanResponse)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
@@ -1,0 +1,29 @@
+import { parseISO } from 'date-fns'
+import { PersonalLearningPlanActionPlan, PersonalLearningPlanGoal } from '../personalLearningPlanGoals'
+import { ActionPlanResponse } from '../educationAndWorkPlanApi/actionPlanResponse'
+import { GoalResponse } from '../educationAndWorkPlanApi/goalResponse'
+
+/**
+ * Simple mapper function to map from the Education And Work Plan (PLP) API type [ActionPlanResponse]
+ * into the view model type [PersonalLearningPlanActionPlan]
+ */
+const toPersonalLearningPlanActionPlan = (
+  apiActionPlanResponse: ActionPlanResponse,
+): PersonalLearningPlanActionPlan => {
+  return {
+    prisonerNumber: apiActionPlanResponse.prisonNumber,
+    goals: apiActionPlanResponse.goals.map(goal => toPersonalLearningPlanGoal(goal)),
+    problemRetrievingData: false,
+  }
+}
+
+const toPersonalLearningPlanGoal = (apiGoalResponse: GoalResponse): PersonalLearningPlanGoal => {
+  return {
+    reference: apiGoalResponse.goalReference,
+    title: apiGoalResponse.title,
+    createdAt: parseISO(apiGoalResponse.createdAt),
+    updatedAt: parseISO(apiGoalResponse.updatedAt),
+  }
+}
+
+export default toPersonalLearningPlanActionPlan

--- a/server/interfaces/personalLearningPlanGoals.ts
+++ b/server/interfaces/personalLearningPlanGoals.ts
@@ -1,0 +1,23 @@
+/**
+ * Interfaces defining Personal Learning Plan (PLP) view model types.
+ *
+ * These types are a deliberate abstraction from the implementation detail of the REST API that returns the data
+ * so as not to tightly couple the view concerns, including the controller, to any given REST API.
+ *
+ * This is particularly relevant in the case of Personal Learning Plan data (specifically, but not limited to Goals)
+ * because there is some thought that HMPPS Digital strategic direction may replace the Education and Work Plan (PLP) API
+ * (or elements of it) with the OnePlan API. This abstraction and loose coupling means that the scope and impact of that
+ * change as and when it happens would be minimal.
+ */
+export interface PersonalLearningPlanActionPlan {
+  prisonerNumber: string
+  goals: Array<PersonalLearningPlanGoal>
+  problemRetrievingData: boolean
+}
+
+export interface PersonalLearningPlanGoal {
+  reference: string
+  title: string
+  createdAt: Date
+  updatedAt: Date
+}

--- a/server/services/personalLearningPlanService.test.ts
+++ b/server/services/personalLearningPlanService.test.ts
@@ -1,0 +1,83 @@
+import { EducationAndWorkPlanApiPersonalLearningPlanService } from './personalLearningPlanService'
+import { aValidActionPlanResponse } from '../data/localMockData/actionPlanResponse'
+import personalLearningPlanActionPlanMapper from '../interfaces/mappers/personalLearningPlanActionPlanMapper'
+import { aValidPersonalLearningPlanActionPlan } from '../data/localMockData/personalLearningPlanActionPlan'
+
+jest.mock('../interfaces/mappers/personalLearningPlanActionPlanMapper')
+
+describe('personalLearningPlanService', () => {
+  const prisonerNumber = 'A1234BC'
+  const systemToken = 'a-system-token'
+
+  describe('EducationAndWorkPlanApiPersonalLearningPlanService', () => {
+    const personalLearningPlanActionPlanMapperMock = personalLearningPlanActionPlanMapper as jest.MockedFunction<
+      typeof personalLearningPlanActionPlanMapper
+    >
+
+    const educationAndWorkPlanApiClientMock = {
+      getPrisonerActionPlan: jest.fn(),
+    }
+    const service = new EducationAndWorkPlanApiPersonalLearningPlanService(() => educationAndWorkPlanApiClientMock)
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should get prisoner action plan given prisoner has a PLP action plan', async () => {
+      // Given
+      const apiActionPlanResponse = aValidActionPlanResponse()
+      educationAndWorkPlanApiClientMock.getPrisonerActionPlan.mockResolvedValue(apiActionPlanResponse)
+
+      const expectedActionPlan = aValidPersonalLearningPlanActionPlan()
+      personalLearningPlanActionPlanMapperMock.mockReturnValue(expectedActionPlan)
+
+      // When
+      const actual = await service.getPrisonerActionPlan(prisonerNumber, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedActionPlan)
+      expect(educationAndWorkPlanApiClientMock.getPrisonerActionPlan).toHaveBeenCalledWith(prisonerNumber)
+      expect(personalLearningPlanActionPlanMapperMock).toHaveBeenCalledWith(apiActionPlanResponse)
+    })
+
+    it('should get empty prisoner action plan given prisoner does not have a PLP action plan', async () => {
+      // Given
+      const apiActionPlanResponse = aValidActionPlanResponse({ goals: [] }) // PLP API does not return a 404, it returns a response regardless, but with an empty goals collection
+      educationAndWorkPlanApiClientMock.getPrisonerActionPlan.mockResolvedValue(apiActionPlanResponse)
+
+      const expectedActionPlan = aValidPersonalLearningPlanActionPlan({ goals: [] })
+      personalLearningPlanActionPlanMapperMock.mockReturnValue(expectedActionPlan)
+
+      // When
+      const actual = await service.getPrisonerActionPlan(prisonerNumber, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedActionPlan)
+      expect(educationAndWorkPlanApiClientMock.getPrisonerActionPlan).toHaveBeenCalledWith(prisonerNumber)
+      expect(personalLearningPlanActionPlanMapperMock).toHaveBeenCalledWith(apiActionPlanResponse)
+    })
+
+    it('should not get prisoner action plan given PLP API throws an error', async () => {
+      // Given
+      const actionPlanApiError = {
+        status: 501,
+        data: {
+          status: 501,
+          userMessage: 'An unexpected error occurred',
+          developerMessage: 'An unexpected error occurred',
+        },
+      }
+      educationAndWorkPlanApiClientMock.getPrisonerActionPlan.mockRejectedValue(actionPlanApiError)
+
+      const expectedActionPlan = { problemRetrievingData: true }
+
+      // When
+      const actual = await service.getPrisonerActionPlan(prisonerNumber, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedActionPlan)
+      expect(educationAndWorkPlanApiClientMock.getPrisonerActionPlan).toHaveBeenCalledWith(prisonerNumber)
+      expect(personalLearningPlanActionPlanMapperMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/services/personalLearningPlanService.ts
+++ b/server/services/personalLearningPlanService.ts
@@ -1,0 +1,37 @@
+import { PersonalLearningPlanActionPlan } from '../interfaces/personalLearningPlanGoals'
+import { EducationAndWorkPlanApiClient } from '../data/interfaces/educationAndWorkPlanApiClient'
+import { RestClientBuilder } from '../data'
+import toPersonalLearningPlanActionPlan from '../interfaces/mappers/personalLearningPlanActionPlanMapper'
+import logger from '../../logger'
+
+/**
+ * Interface defining the Personal Learning Plan service methods.
+ *
+ * Concrete implementations are free to use whatever API or other data source in order to implement the service methods.
+ * The use of this interface and the data type abstractions allow other implementations that use other API data sources
+ * to be swapped in as and when necessary.
+ */
+export interface PersonalLearningPlanService {
+  getPrisonerActionPlan(prisonerNumber: string, systemToken: string): Promise<PersonalLearningPlanActionPlan>
+}
+
+/**
+ * Implementation of [PersonalLearningPlanService] that uses the [EducationAndWorkPlanApiClient] as data source
+ * for PLP related data.
+ */
+export class EducationAndWorkPlanApiPersonalLearningPlanService implements PersonalLearningPlanService {
+  constructor(
+    private readonly educationAndWorkPlanApiClientBuilder: RestClientBuilder<EducationAndWorkPlanApiClient>,
+  ) {}
+
+  async getPrisonerActionPlan(prisonerNumber: string, systemToken: string): Promise<PersonalLearningPlanActionPlan> {
+    try {
+      const plpActionPlan =
+        await this.educationAndWorkPlanApiClientBuilder(systemToken).getPrisonerActionPlan(prisonerNumber)
+      return toPersonalLearningPlanActionPlan(plpActionPlan)
+    } catch (error) {
+      logger.error('Error calling the Education And Work Plan API to get the prisoner action plan', error)
+      return { problemRetrievingData: true } as PersonalLearningPlanActionPlan
+    }
+  }
+}


### PR DESCRIPTION
This PR is not massive, but adds some important classes relating to getting PLP Goal data. It adds:

* A couple of abstractions of the data that the PLP API returns - `PersonalLearningPlanActionPlan` and `PersonalLearningPlanGoal`. These are basically view models and are not tied to the API response data
* A mapper function, to map between `ActionPlanResponse` (the API response data) and `PersonalLearningPlanActionPlan` (the above view model)
* A service interface `PersonalLearningPlanService` and a concrete implementation `EducationAndWorkPlanApiPersonalLearningPlanService` that uses the `EducationAndWorkPlanApiClient` (aka. PLP API client) to get the PLP Goal related data

The PLP dev team will be familiar with this approach as this is what we've been doing throughout in the PLP and CIAG UI's that we've worked on to date. But for the benefit of others:

The idea of the view models is that they represent the needs of the screen, rather than the specific data that a given API might return. APIs change over time, and may even be swapped out for something else, so not coupling the controller and/or nunjucks views to the API response data is good thing 👍 

The reason I've added an interface for the service class and method (none of the other service classes in this repo have one) is related to the above (decoupling), but specifically because there is a thought that one day the PLP API might be replaced/migrated to the OnePlan API. When that happens PLP Goals will still be a "thing" - they will still be a business domain/concern, and we'll still need to display them on the Work & Skills tab. It's just that we'll get them from a different REST API .... and the API response data might (probably will) look different.
When that happens, it should be an easy job to write a new REST API client class, an implementation of the service interface (that uses the new OnePlan REST API client class), and a new mapper to map from the "new shape" API data returned from the OncePlan REST API to the `PersonalLearningPlanActionPlan` view model.
This approach means that we have a nice loose coupling between an API implementation and the view concerns. Loose coupling and programming to interfaces FTW 😁 
(@martin-ballhatchet-moj - FYI re: your concern that we did not couple prisoner-profile to the PLP API and could easily swap in the OnePlan API as and when 👍 )

Last point of interest is a field in the view model type `PersonalLearningPlanActionPlan` called `problemRetrievingData`.
This is a basic/simple mechanism (that we've adopted in PLP and CIAG UIs) that allows for the API call to fail but not break the page or user journey. It's really simple - the service class wraps the API call in a `try/catch`. If the API call fails, the `catch` block returns an instance of the `PersonalLearningPlanActionPlan` view model, but with `problemRetrievingData` set to true. Then at the controller or (more likely) nunjucks view layer (neither in this PR) we can write a simple if statement that says "if problemRetrievingData display some message saying try again later or similar"
(@williamfalconeruk - the above paragraph relates to the conversation we had earlier re: error handling of API calls and how not to break the page/journey. I'll send you some screen shots/examples from PLP of how this works in practice)

