### PR TITLE
RR-583 add info text to the employability skills section

### DIFF
--- a/integration_tests/e2e/workAndSkillsPage.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage.cy.ts
@@ -161,6 +161,7 @@ context('Work and skills page', () => {
           workAndSkillsPage.ES_header().should('exist')
           workAndSkillsPage.ES_header().contains('Employability skills')
           workAndSkillsPage.ES_heading().contains('Most recent levels')
+          workAndSkillsPage.ES_info().should('exist')
           workAndSkillsPage.ES_skillOne().contains('string')
           workAndSkillsPage.ES_skillLevelOne().contains('string')
         })

--- a/integration_tests/pages/workAndSkillsPage.ts
+++ b/integration_tests/pages/workAndSkillsPage.ts
@@ -75,6 +75,8 @@ export default class WorkAndSkillsPage extends Page {
 
   ES_heading = (): PageElement => cy.get('#employability-skills > .hmpps-summary-card__body > .govuk-heading-s')
 
+  ES_info = (): PageElement => cy.get('#employability-skills > .hmpps-summary-card__body > p')
+
   ES_skillOne = (): PageElement => cy.get('.govuk-grid-column-one-third > .govuk-body')
 
   ES_skillLevelOne = (): PageElement => cy.get('.govuk-grid-column-two-thirds > p')

--- a/server/views/partials/new_workAndSkillsPage/employabilitySkills.njk
+++ b/server/views/partials/new_workAndSkillsPage/employabilitySkills.njk
@@ -1,5 +1,6 @@
 {% from "../../macros/summaryCardMacro.njk" import summaryCard %}
 {%- call summaryCard({title: "Employability skills", id: "employability-skills", classes: "hmpps-employability-card"}) -%}
+    <p>The local education team record these employability skills in Curious.</p>
     <h3 class="govuk-heading-s">Most recent levels</h3>
     {% if learnerEmployabilitySkills.content.length > 0 %}
         {% for item in learnerEmployabilitySkills.content %}


### PR DESCRIPTION
## Description

Add information text to the Employability skills section on the new Work & Skills tab as part of the work that the PLP team are doing in the EPIC https://dsdmoj.atlassian.net/browse/RR-575

### JIRA ticket

https://dsdmoj.atlassian.net/browse/RR-583

### Screenshots

Prisoner with employability skills (`G6123VU`)

![screencapture-localhost-3000-prisoner-G6123VU-work-and-skills-2024-02-01-10_02_25](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/11615501/83366bd7-0f2c-4f71-a30c-fe2382c38670)

Prisoner without employability skills (`G9981UK`)

![screencapture-localhost-3000-prisoner-G9981UK-work-and-skills-2024-02-01-10_03_33](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/11615501/4f9c2833-71cc-4d42-9586-391db371ddd3)
