### PR TITLE
RR-585 reorder the work and skills tab sections

### DIFF
--- a/server/views/pages/new_workAndSkills.njk
+++ b/server/views/pages/new_workAndSkills.njk
@@ -29,6 +29,11 @@
     <div class="govuk-grid-column-three-quarters">
       <div class="govuk-grid-row" data-qa="courses-and-qualifications">
         <div class="govuk-grid-column-full">
+          {% include "../partials/new_workAndSkillsPage/functionalSkillsLevel.njk" %}
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
           {% include "../partials/new_workAndSkillsPage/coursesAndQualifications.njk" %}
         </div>
       </div>
@@ -39,17 +44,12 @@
       </div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          {% include "../partials/new_workAndSkillsPage/employabilitySkills.njk" %}
-        </div>
-      </div>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
           {% include "../partials/new_workAndSkillsPage/goals.njk" %}
         </div>
       </div>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          {% include "../partials/new_workAndSkillsPage/functionalSkillsLevel.njk" %}
+          {% include "../partials/new_workAndSkillsPage/employabilitySkills.njk" %}
         </div>
       </div>
     </div>

--- a/server/views/pages/new_workAndSkills.njk
+++ b/server/views/pages/new_workAndSkills.njk
@@ -19,11 +19,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter app-sidebar">
       <ul class="govuk-list hmpps-sidebar">
+        <li><a class="govuk-link" href="#functional-skills-level">Functional skills level</a></li>
         <li><a class="govuk-link" href="#courses-and-qualifications">Courses and qualifications</a></li>
         <li><a class="govuk-link" href="#work-and-activities">Work and activities</a></li>
-        <li><a class="govuk-link" href="#employability-skills">Employability skills</a></li>
         <li><a class="govuk-link" href="#goals">Goals</a></li>
-        <li><a class="govuk-link" href="#functional-skills-level">Functional skills level</a></li>
+        <li><a class="govuk-link" href="#employability-skills">Employability skills</a></li>
       </ul>
     </div>
     <div class="govuk-grid-column-three-quarters">


### PR DESCRIPTION
## Description

As part of the work the PLP team are doing, re-order the sections on the new Work & skills page.

> Currently they are in this order:
> - Courses and qualifications
> - Work and activities
> - Employability skills
> - Goals
> - Functional skills levels
> 
> We would like to reorder them as such:
> 
> - Functional skills levels
> - Courses and qualifications
> - Work and activities
> - Goals
> - Employability skills

### JIRA 

https://dsdmoj.atlassian.net/browse/RR-585