### PR TITLE
RR-584 - Map the last updated by/at fields into `PersonalLearningPlanActionPlan`

### DIFF
--- a/server/data/localMockData/actionPlanResponse.ts
+++ b/server/data/localMockData/actionPlanResponse.ts
@@ -22,19 +22,23 @@ const aValidGoalResponse = (options?: {
   reference?: string
   title?: string
   createdAt?: string
+  createdBy?: string
+  createdByDisplayName?: string
   updatedAt?: string
+  updatedBy?: string
+  updatedByDisplayName?: string
 }): GoalResponse => {
   return {
     goalReference: options?.reference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
     title: options?.title || 'Learn Spanish',
     status: 'ACTIVE',
     steps: [aValidFirstStepResponse(), aValidSecondStepResponse()],
-    createdBy: 'asmith_gen',
-    createdByDisplayName: 'Alex Smith',
+    createdBy: options?.createdBy || 'asmith_gen',
+    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
     createdAt: options?.createdAt || '2023-01-16T09:14:43.158Z',
     createdAtPrison: 'MDI',
-    updatedBy: 'asmith_gen',
-    updatedByDisplayName: 'Alex Smith',
+    updatedBy: options?.updatedBy || 'asmith_gen',
+    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
     updatedAt: options?.updatedAt || '2023-09-23T14:43:02.094Z',
     updatedAtPrison: 'MDI',
     targetCompletionDate: '2024-02-29',

--- a/server/data/localMockData/personalLearningPlanActionPlan.ts
+++ b/server/data/localMockData/personalLearningPlanActionPlan.ts
@@ -4,9 +4,11 @@ const aValidPersonalLearningPlanActionPlan = (options?: {
   prisonerNumber?: string
   goals?: Array<PersonalLearningPlanGoal>
 }): PersonalLearningPlanActionPlan => {
+  const goals = options?.goals || [aValidPersonalLearningPlanGoal()]
   return {
     prisonerNumber: options?.prisonerNumber || 'A1234BC',
-    goals: options?.goals || [aValidPersonalLearningPlanGoal()],
+    goals,
+    ...getLastUpdatedAuditFields(goals),
     problemRetrievingData: false,
   }
 }
@@ -15,14 +17,47 @@ const aValidPersonalLearningPlanGoal = (options?: {
   reference?: string
   title?: string
   createdAt?: Date
+  createdBy?: string
+  createdByDisplayName?: string
   updatedAt?: Date
+  updatedBy?: string
+  updatedByDisplayName?: string
 }): PersonalLearningPlanGoal => {
   return {
     reference: options?.reference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
     title: options?.title || 'Learn Spanish',
+    createdBy: options?.createdBy || 'asmith_gen',
+    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
     createdAt: options?.createdAt || new Date('2023-01-16T09:14:43.158Z'),
+    updatedBy: options?.updatedBy || 'asmith_gen',
+    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
     updatedAt: options?.updatedAt || new Date('2023-09-23T14:43:02.094Z'),
   }
+}
+
+const getLastUpdatedAuditFields = (
+  goals: Array<PersonalLearningPlanGoal>,
+): { updatedBy?: string; updatedByDisplayName?: string; updatedAt?: Date } => {
+  if (goals.length === 0) {
+    return { updatedBy: undefined, updatedByDisplayName: undefined, updatedAt: undefined }
+  }
+
+  const mostRecentGoal = goals.sort(goalComparator)[0]
+  return {
+    updatedBy: mostRecentGoal.updatedBy,
+    updatedByDisplayName: mostRecentGoal.updatedByDisplayName,
+    updatedAt: mostRecentGoal.updatedAt,
+  }
+}
+
+const goalComparator = (left: PersonalLearningPlanGoal, right: PersonalLearningPlanGoal): number => {
+  if (left.updatedAt > right.updatedAt) {
+    return -1
+  }
+  if (left.updatedAt < right.updatedAt) {
+    return 1
+  }
+  return 0
 }
 
 export { aValidPersonalLearningPlanActionPlan, aValidPersonalLearningPlanGoal }

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
@@ -13,13 +13,21 @@ describe('personalLearningPlanActionPlanMapper', () => {
           title: 'Learn French',
           reference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
           createdAt: '2023-01-16T09:14:43.158Z',
+          createdBy: 'user_a',
+          createdByDisplayName: 'User A',
           updatedAt: '2023-09-23T14:43:02.094Z',
+          updatedBy: 'user_b',
+          updatedByDisplayName: 'User B',
         }),
         aValidGoalResponse({
           title: 'Learn basic carpentry',
           reference: '30b8abe1-736f-426d-87a7-0e1a7f2f63ab',
           createdAt: '2023-03-20T10:24:03.651Z',
+          createdBy: 'user_c',
+          createdByDisplayName: 'User C',
           updatedAt: '2023-07-01T11:14:43.017Z',
+          updatedBy: 'user_d',
+          updatedByDisplayName: 'User D',
         }),
       ],
     })
@@ -31,15 +39,50 @@ describe('personalLearningPlanActionPlanMapper', () => {
           reference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
           title: 'Learn French',
           createdAt: new Date('2023-01-16T09:14:43.158Z'),
+          createdBy: 'user_a',
+          createdByDisplayName: 'User A',
           updatedAt: new Date('2023-09-23T14:43:02.094Z'),
+          updatedBy: 'user_b',
+          updatedByDisplayName: 'User B',
         },
         {
           reference: '30b8abe1-736f-426d-87a7-0e1a7f2f63ab',
           title: 'Learn basic carpentry',
           createdAt: new Date('2023-03-20T10:24:03.651Z'),
+          createdBy: 'user_c',
+          createdByDisplayName: 'User C',
           updatedAt: new Date('2023-07-01T11:14:43.017Z'),
+          updatedBy: 'user_d',
+          updatedByDisplayName: 'User D',
         },
       ],
+      updatedAt: new Date('2023-09-23T14:43:02.094Z'),
+      updatedBy: 'user_b',
+      updatedByDisplayName: 'User B',
+      problemRetrievingData: false,
+    }
+
+    // When
+    const actual = toPersonalLearningPlanActionPlan(apiActionPlanResponse)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to PersonalLearningPlanActionPlan given ActionPlanResponse with no goals', () => {
+    // Given
+    const apiActionPlanResponse = aValidActionPlanResponse({
+      reference: 'a20912ab-4dae-4aa4-8bc5-32319da8fceb',
+      prisonNumber: 'A1234BC',
+      goals: [],
+    })
+
+    const expected: PersonalLearningPlanActionPlan = {
+      prisonerNumber: 'A1234BC',
+      goals: [],
+      updatedAt: undefined,
+      updatedBy: undefined,
+      updatedByDisplayName: undefined,
       problemRetrievingData: false,
     }
 

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
@@ -10,10 +10,32 @@ import { GoalResponse } from '../educationAndWorkPlanApi/goalResponse'
 const toPersonalLearningPlanActionPlan = (
   apiActionPlanResponse: ActionPlanResponse,
 ): PersonalLearningPlanActionPlan => {
+  const goals = apiActionPlanResponse.goals.map(goal => toPersonalLearningPlanGoal(goal))
   return {
     prisonerNumber: apiActionPlanResponse.prisonNumber,
-    goals: apiActionPlanResponse.goals.map(goal => toPersonalLearningPlanGoal(goal)),
+    goals,
+    ...getLastUpdatedAuditFields(goals),
     problemRetrievingData: false,
+  }
+}
+
+/**
+ * Given an array of [GoalResponse] returns the "last updated at/by" audit fields for the [GoalResponse] that was updated
+ * most recently.
+ * If the specified array of [GoalResponse] is empty then the 3 fields will be returned as `undefined`
+ */
+const getLastUpdatedAuditFields = (
+  goals: Array<PersonalLearningPlanGoal>,
+): { updatedBy?: string; updatedByDisplayName?: string; updatedAt?: Date } => {
+  if (goals.length === 0) {
+    return { updatedBy: undefined, updatedByDisplayName: undefined, updatedAt: undefined }
+  }
+
+  const mostRecentGoal = goals.sort(goalComparator)[0]
+  return {
+    updatedBy: mostRecentGoal.updatedBy,
+    updatedByDisplayName: mostRecentGoal.updatedByDisplayName,
+    updatedAt: mostRecentGoal.updatedAt,
   }
 }
 
@@ -22,8 +44,22 @@ const toPersonalLearningPlanGoal = (apiGoalResponse: GoalResponse): PersonalLear
     reference: apiGoalResponse.goalReference,
     title: apiGoalResponse.title,
     createdAt: parseISO(apiGoalResponse.createdAt),
+    createdBy: apiGoalResponse.createdBy,
+    createdByDisplayName: apiGoalResponse.createdByDisplayName,
     updatedAt: parseISO(apiGoalResponse.updatedAt),
+    updatedBy: apiGoalResponse.updatedBy,
+    updatedByDisplayName: apiGoalResponse.updatedByDisplayName,
   }
+}
+
+const goalComparator = (left: PersonalLearningPlanGoal, right: PersonalLearningPlanGoal): number => {
+  if (left.updatedAt > right.updatedAt) {
+    return -1
+  }
+  if (left.updatedAt < right.updatedAt) {
+    return 1
+  }
+  return 0
 }
 
 export default toPersonalLearningPlanActionPlan

--- a/server/interfaces/personalLearningPlanGoals.ts
+++ b/server/interfaces/personalLearningPlanGoals.ts
@@ -12,6 +12,9 @@
 export interface PersonalLearningPlanActionPlan {
   prisonerNumber: string
   goals: Array<PersonalLearningPlanGoal>
+  updatedBy?: string
+  updatedByDisplayName?: string
+  updatedAt?: Date
   problemRetrievingData: boolean
 }
 
@@ -19,5 +22,9 @@ export interface PersonalLearningPlanGoal {
   reference: string
   title: string
   createdAt: Date
+  createdBy: string
+  createdByDisplayName: string
   updatedAt: Date
+  updatedBy: string
+  updatedByDisplayName: string
 }


### PR DESCRIPTION
This PR adds the last updated by/at fields to `PersonalLearningPlanActionPlan` and `PersonalLearningPlanGoal`, as I forgot to add these when I first committed the types and mapper functions.

The only minor bit of complexity here is that the last updated by/at fields for the `PersonalLearningPlanActionPlan` needs to be the values from the most recently updated `PersonalLearningPlanGoal`