### PR TITLE
RR-584 - Skeleton cypress tests for new Goals summary card scenarios on W&S tab

### DIFF
--- a/integration_tests/e2e/vc2GoalsPage.cy.ts
+++ b/integration_tests/e2e/vc2GoalsPage.cy.ts
@@ -14,7 +14,7 @@ context('Prisoners VC2 goals page', () => {
 
   it('should contain a banner about learning and work progress service replacing VC2', () => {
     // Given
-    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU', emptyStates: false })
+    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU' })
     visitGoalsPage()
 
     // When
@@ -26,7 +26,7 @@ context('Prisoners VC2 goals page', () => {
 
   it('should display goals from VC2', () => {
     // Given
-    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU', emptyStates: false })
+    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU' })
     visitGoalsPage()
 
     // When
@@ -41,7 +41,8 @@ context('Prisoners VC2 goals page', () => {
 
   it('should display no goals message given there are no goals in VC2', () => {
     // Given
-    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU', emptyStates: true })
+    cy.setupWorkAndSkillsPageStubs({ prisonerNumber: 'G6123VU' })
+    cy.task('stubGetCuriousGoalsForPrisonerWithNoGoals')
     visitGoalsPage()
 
     // When

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsCoursesAndQualifications.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsCoursesAndQualifications.cy.ts
@@ -17,7 +17,7 @@ context('Work and skills page - Courses And Qualification Card', () => {
       const prisonerNumber = 'G6123VU'
       beforeEach(() => {
         cy.setupBannerStubs({ prisonerNumber })
-        cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+        cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
         visitWorkAndSkillsPage()
       })
 

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsEmployabilitySkills.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsEmployabilitySkills.cy.ts
@@ -17,7 +17,7 @@ context('Work and skills page - Employability Skills Card', () => {
       const prisonerNumber = 'G6123VU'
       beforeEach(() => {
         cy.setupBannerStubs({ prisonerNumber })
-        cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+        cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
         visitWorkAndSkillsPage()
       })
 

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsFunctionalSkills.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsFunctionalSkills.cy.ts
@@ -17,7 +17,7 @@ context('Work and skills page - Functional Skills Card', () => {
       const prisonerNumber = 'G6123VU'
       beforeEach(() => {
         cy.setupBannerStubs({ prisonerNumber })
-        cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+        cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
         visitWorkAndSkillsPage()
       })
 

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
@@ -117,6 +117,7 @@ context('Work and skills page - Goals card', () => {
 
     // Then
     const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
     // TODO - add relevant page assertions once the implementation has been completed
   })
 
@@ -130,6 +131,7 @@ context('Work and skills page - Goals card', () => {
 
     // Then
     const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
     // TODO - add relevant page assertions once the implementation has been completed
   })
 
@@ -143,6 +145,7 @@ context('Work and skills page - Goals card', () => {
 
     // Then
     const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
     // TODO - add relevant page assertions once the implementation has been completed
   })
 
@@ -156,6 +159,7 @@ context('Work and skills page - Goals card', () => {
 
     // Then
     const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
     // TODO - add relevant page assertions once the implementation has been completed
   })
 })

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
@@ -13,11 +13,13 @@ context('Work and skills page - Goals card', () => {
     cy.task('reset')
     cy.setupUserAuth()
     cy.setupBannerStubs({ prisonerNumber })
+    cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
   })
 
-  it('should display the Goals card with populated goals given prisoner has goals', () => {
+  it('should display the Goals card with populated goals given prisoner has VC2 goals only', () => {
     // Given
-    cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+    cy.task('stubGetCuriousGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlanForPrisonerWithNoGoals', prisonerNumber)
 
     // When
     visitWorkAndSkillsPage()
@@ -62,7 +64,8 @@ context('Work and skills page - Goals card', () => {
 
   it('should display the Goals card with no populated goals given prisoner has no goals', () => {
     // Given
-    cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: true })
+    cy.task('stubGetCuriousGoalsForPrisonerWithNoGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlanForPrisonerWithNoGoals', prisonerNumber)
 
     // When
     visitWorkAndSkillsPage()
@@ -102,5 +105,57 @@ context('Work and skills page - Goals card', () => {
 
     workAndSkillsPage.GoalsLongTermText().should('exist')
     workAndSkillsPage.GoalsLongTermText().contains('The prisoner does not have any long term goals.')
+  })
+
+  it.skip('should display the Goals card with populated goals given prisoner has PLP goals only', () => {
+    // Given
+    cy.task('stubGetCuriousGoalsForPrisonerWithNoGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlan', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    // TODO - add relevant page assertions once the implementation has been completed
+  })
+
+  it.skip('should display the Goals card with populated goals given prisoner has both PLP and VC2 goals', () => {
+    // Given
+    cy.task('stubGetCuriousGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlan', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    // TODO - add relevant page assertions once the implementation has been completed
+  })
+
+  it.skip('should display the Goals card informing the user the Goals could not be retrieved given there was a problem getting the VC2 goals', () => {
+    // Given
+    cy.task('stubGetCuriousGoals500Error', prisonerNumber)
+    cy.task('stubGetPlpActionPlan', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    // TODO - add relevant page assertions once the implementation has been completed
+  })
+
+  it.skip('should display the Goals card informing the user the Goals could not be retrieved given there was a problem getting the PLP goals', () => {
+    // Given
+    cy.task('stubGetCuriousGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlan500Error', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    // TODO - add relevant page assertions once the implementation has been completed
   })
 })

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsPage.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsPage.cy.ts
@@ -13,7 +13,7 @@ context('Work and skills page', () => {
     const prisonerNumber = 'G6123VU'
     const visitPage = prisonerDataOverrides => {
       cy.setupBannerStubs({ prisonerNumber, prisonerDataOverrides })
-      cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+      cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
       visitWorkAndSkillsPage({ failOnStatusCode: false })
     }
 
@@ -29,7 +29,7 @@ context('Work and skills page', () => {
         caseLoads: [{ caseloadFunction: '', caseLoadId: '123', currentlyActive: true, description: '', type: '' }],
       })
       cy.setupBannerStubs({ prisonerNumber })
-      cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+      cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
     })
 
     it('Doesnt dislpay the link to the 7 day schedule', () => {
@@ -48,7 +48,7 @@ context('Work and skills page', () => {
       const prisonerNumber = 'G6123VU'
       beforeEach(() => {
         cy.setupBannerStubs({ prisonerNumber })
-        cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+        cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
         visitWorkAndSkillsPage()
       })
 

--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsWorkAndActivities.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsWorkAndActivities.cy.ts
@@ -17,7 +17,7 @@ context('Work and skills page - Work And Activities Card', () => {
       const prisonerNumber = 'G6123VU'
       beforeEach(() => {
         cy.setupBannerStubs({ prisonerNumber })
-        cy.setupWorkAndSkillsPageStubs({ prisonerNumber, emptyStates: false })
+        cy.setupWorkAndSkillsPageStubs({ prisonerNumber })
         visitWorkAndSkillsPage()
       })
 

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -36,7 +36,7 @@ declare global {
         prisonerDataOverrides?: Partial<Prisoner>
         caseLoads?: CaseLoad[]
       }): Chainable<AUTWindow>
-      setupWorkAndSkillsPageStubs(options: { prisonerNumber: string; emptyStates: boolean }): Chainable<AUTWindow>
+      setupWorkAndSkillsPageStubs(options: { prisonerNumber: string; emptyStates?: boolean }): Chainable<AUTWindow>
       setupOffencesPageSentencedStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
       setupOffencesPageUnsentencedStubs(options: { prisonerNumber: string; bookingId: number }): Chainable<AUTWindow>
       setupUserAuth(options?: {

--- a/integration_tests/mockApis/curiousApi.ts
+++ b/integration_tests/mockApis/curiousApi.ts
@@ -73,18 +73,9 @@ export default {
       },
     })
   },
-  stubGetCuriousGoals: (options?: { prisonerNumber?: string; emptyStates?: boolean }) => {
-    const prisonerNumber = options?.prisonerNumber || 'G6123VU'
-    const responseBody =
-      !options || options.emptyStates === null || options.emptyStates === undefined || options.emptyStates === false
-        ? aValidLearnerGoals({ prn: prisonerNumber })
-        : aValidLearnerGoals({
-            prn: prisonerNumber,
-            employmentGoals: [],
-            personalGoals: [],
-            longTermGoals: [],
-            shortTermGoals: [],
-          })
+
+  stubGetCuriousGoals: (prisonerNumber = 'G6123VU') => {
+    const responseBodyForPrisonerWithGoals = aValidLearnerGoals({ prn: prisonerNumber })
 
     return stubFor({
       request: {
@@ -96,10 +87,53 @@ export default {
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: responseBody,
+        jsonBody: responseBodyForPrisonerWithGoals,
       },
     })
   },
+
+  stubGetCuriousGoalsForPrisonerWithNoGoals: (prisonerNumber = 'G6123VU') => {
+    const responseBodyForPrisonerWithNoGoals = aValidLearnerGoals({
+      prn: prisonerNumber,
+      employmentGoals: [],
+      personalGoals: [],
+      longTermGoals: [],
+      shortTermGoals: [],
+    })
+
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/curiousApi/learnerGoals/${prisonerNumber}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: responseBodyForPrisonerWithNoGoals,
+      },
+    })
+  },
+
+  stubGetCuriousGoals500Error: (prisonerNumber = 'G6123VU') => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/curiousApi/learnerGoals/${prisonerNumber}`,
+      },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          errorCode: 'VC5001',
+          errorMessage: 'Service unavailable',
+          httpStatusCode: 500,
+        },
+      },
+    })
+  },
+
   stubGetLearnerNeurodivergence: (prisonerNumber: string) => {
     return stubFor({
       request: {

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -74,12 +74,12 @@ Cypress.Commands.add('setupAlertsPageStubs', ({ bookingId, prisonerNumber, priso
   }
 })
 
-Cypress.Commands.add('setupWorkAndSkillsPageStubs', ({ prisonerNumber, emptyStates }) => {
+Cypress.Commands.add('setupWorkAndSkillsPageStubs', ({ prisonerNumber, emptyStates = false }) => {
   cy.task('stubGetLearnerEmployabilitySkills', prisonerNumber)
   cy.task('stubGetLearnerEducation', prisonerNumber)
   cy.task('stubGetLearnerProfile', prisonerNumber)
   cy.task('stubGetLearnerLatestAssessments', prisonerNumber)
-  cy.task('stubGetCuriousGoals', { prisonerNumber, emptyStates })
+  cy.task('stubGetCuriousGoals', prisonerNumber)
   cy.task('stubGetLearnerNeurodivergence', prisonerNumber)
   cy.task('stubGetOffenderAttendanceHistory', prisonerNumber)
   cy.task('stubGetOffenderActivities', { prisonerNumber, emptyStates })


### PR DESCRIPTION
This PR does a little refactoring to the cypress wiremock stubs in respect of the Curious API (to make it easier for a cypress test to say it wants one that returns goals, one that returns no goals, or one that returns an error); and then adds the skeleton methods for new cypress tests that we are about to implement
The new cypress tests are all defined with `it.skip` for the time being - they have the correct scenario description and setup in respect of wiremock stubs; the last thing they need is for the relevant assertions to be written for the rendered page content which will come after @chrimesdev 's current work