### PR TITLE
RR-584 - Fixes the handling of inconsistent Curious API response for prisoners without goals

### DIFF
--- a/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
+++ b/integration_tests/e2e/workAndSkillsPage/workAndSkillsGoals.cy.ts
@@ -30,7 +30,7 @@ context('Work and skills page - Goals card', () => {
     workAndSkillsPage.Vc2GoalsSummary().should('exist')
   })
 
-  it('should display the Goals card with no populated goals given prisoner has no goals', () => {
+  it('should display the Goals card with no populated goals given prisoner has no goals (empty goals from Curious)', () => {
     // Given
     cy.task('stubGetCuriousGoalsForPrisonerWithNoGoals', prisonerNumber)
     cy.task('stubGetPlpActionPlanForPrisonerWithNoGoals', prisonerNumber)
@@ -44,9 +44,37 @@ context('Work and skills page - Goals card', () => {
     workAndSkillsPage.NoGoalsSummary().should('exist')
   })
 
-  it('should display the Goals card with populated goals given prisoner has PLP goals only', () => {
+  it('should display the Goals card with no populated goals given prisoner has no goals (404 from Curious)', () => {
+    // Given
+    cy.task('stubGetCuriousGoals404Error', prisonerNumber)
+    cy.task('stubGetPlpActionPlanForPrisonerWithNoGoals', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
+    workAndSkillsPage.NoGoalsSummary().should('exist')
+  })
+
+  it('should display the Goals card with populated goals given prisoner has PLP goals only (empty goals from Curious)', () => {
     // Given
     cy.task('stubGetCuriousGoalsForPrisonerWithNoGoals', prisonerNumber)
+    cy.task('stubGetPlpActionPlan', prisonerNumber)
+
+    // When
+    visitWorkAndSkillsPage()
+
+    // Then
+    const workAndSkillsPage = Page.verifyOnPage(WorkAndSkillsPage)
+    workAndSkillsPage.GoalsInfo().should('exist')
+    workAndSkillsPage.PlpGoalsSummary().should('exist')
+  })
+
+  it('should display the Goals card with populated goals given prisoner has PLP goals only (404 from Curious)', () => {
+    // Given
+    cy.task('stubGetCuriousGoals404Error', prisonerNumber)
     cy.task('stubGetPlpActionPlan', prisonerNumber)
 
     // When

--- a/integration_tests/mockApis/curiousApi.ts
+++ b/integration_tests/mockApis/curiousApi.ts
@@ -116,6 +116,24 @@ export default {
     })
   },
 
+  stubGetCuriousGoals404Error: (prisonerNumber = 'G6123VU') => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/curiousApi/learnerGoals/${prisonerNumber}`,
+      },
+      response: {
+        status: 404,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          errorCode: 'VC4004',
+          errorMessage: 'Resource not found',
+          httpStatusCode: 404,
+        },
+      },
+    })
+  },
+
   stubGetCuriousGoals500Error: (prisonerNumber = 'G6123VU') => {
     return stubFor({
       request: {

--- a/server/services/workAndSkillsPageService.ts
+++ b/server/services/workAndSkillsPageService.ts
@@ -208,7 +208,7 @@ export default class WorkAndSkillsPageService {
   private async getCuriousGoals(prisonerNumber: string, curiousApiClient: CuriousApiClient): Promise<CuriousGoals> {
     try {
       const learnerGoals = await curiousApiClient.getLearnerGoals(prisonerNumber)
-      return toCuriousGoals(learnerGoals)
+      return learnerGoals ? toCuriousGoals(learnerGoals) : emptyCuriousGoals(prisonerNumber)
     } catch (error) {
       logger.error(`Error calling the Curious API to get the prisoner's goals`, error)
       return { problemRetrievingData: true } as CuriousGoals
@@ -229,5 +229,16 @@ export default class WorkAndSkillsPageService {
     const learnerNeurodivergence: LearnerNeurodivergence[] =
       await curiousApiClient.getLearnerNeurodivergence(prisonerNumber)
     return learnerNeurodivergence
+  }
+}
+
+const emptyCuriousGoals = (prisonerNumber: string): CuriousGoals => {
+  return {
+    prisonerNumber,
+    employmentGoals: [],
+    personalGoals: [],
+    longTermGoals: [],
+    shortTermGoals: [],
+    problemRetrievingData: false,
   }
 }


### PR DESCRIPTION
This PR fixes a bug which centres around some poor/inconsistent responses from the Curious API for prisoners without any goals.
From testing in `dev` we have found that some prisoners get a 200 response with a response body like this:
```
{
    "prn": "G9981UK",
    "employmentGoals": [],
    "personalGoals": [],
    "longTermGoals": [],
    "shortTermGoals": []
}
```

whilst others get a 404 response with a response body like this:
```
{
    "errorCode": "VC4004",
    "errorMessage": "Resource not found",
    "httpStatusCode": 404
}
```

This PR handles that inconsistency 🙄 , with suitable unit and cypress tests to prove and aid documentation of this "odd-ness" !