### PR TITLE
RR-622 - Add and correctly populate `sequenceNumber` to the `PersonalLearningPlanGoal` view model

### DIFF
--- a/server/data/localMockData/personalLearningPlanActionPlan.ts
+++ b/server/data/localMockData/personalLearningPlanActionPlan.ts
@@ -22,6 +22,7 @@ const aValidPersonalLearningPlanGoal = (options?: {
   updatedAt?: Date
   updatedBy?: string
   updatedByDisplayName?: string
+  sequenceNumber?: number
 }): PersonalLearningPlanGoal => {
   return {
     reference: options?.reference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
@@ -32,6 +33,7 @@ const aValidPersonalLearningPlanGoal = (options?: {
     updatedBy: options?.updatedBy || 'asmith_gen',
     updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
     updatedAt: options?.updatedAt || new Date('2023-09-23T14:43:02.094Z'),
+    sequenceNumber: options?.sequenceNumber || 1,
   }
 }
 

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.test.ts
@@ -44,6 +44,7 @@ describe('personalLearningPlanActionPlanMapper', () => {
           updatedAt: new Date('2023-09-23T14:43:02.094Z'),
           updatedBy: 'user_b',
           updatedByDisplayName: 'User B',
+          sequenceNumber: 1,
         },
         {
           reference: '30b8abe1-736f-426d-87a7-0e1a7f2f63ab',
@@ -54,6 +55,7 @@ describe('personalLearningPlanActionPlanMapper', () => {
           updatedAt: new Date('2023-07-01T11:14:43.017Z'),
           updatedBy: 'user_d',
           updatedByDisplayName: 'User D',
+          sequenceNumber: 2,
         },
       ],
       updatedAt: new Date('2023-09-23T14:43:02.094Z'),

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
@@ -35,7 +35,7 @@ const getLastUpdatedAuditFields = (
   }
 
   const mostRecentlyUpdatedGoal = [...goals].sort((left: GoalResponse, right: GoalResponse) =>
-    dateComparator(parseISO(left.updatedAt), parseISO(right.updatedAt)),
+    dateComparator(parseISO(left.updatedAt), parseISO(right.updatedAt), 'DESC'),
   )[0]
   return {
     updatedBy: mostRecentlyUpdatedGoal.updatedBy,
@@ -61,12 +61,12 @@ const toPersonalLearningPlanGoal = (
   }
 }
 
-const dateComparator = (left: Date, right: Date): number => {
+const dateComparator = (left: Date, right: Date, direction: 'ASC' | 'DESC' = 'DESC'): number => {
   if (left > right) {
-    return -1
+    return direction === 'DESC' ? -1 : 1
   }
   if (left < right) {
-    return 1
+    return direction === 'DESC' ? 1 : -1
   }
   return 0
 }
@@ -77,9 +77,8 @@ const dateComparator = (left: Date, right: Date): number => {
  */
 const goalReferencesSortedByCreationDate = (goals: Array<GoalResponse>): Array<string> => {
   return [...goals]
-    .sort(
-      (left: GoalResponse, right: GoalResponse) =>
-        dateComparator(parseISO(left.createdAt), parseISO(right.createdAt)) * -1,
+    .sort((left: GoalResponse, right: GoalResponse) =>
+      dateComparator(parseISO(left.createdAt), parseISO(right.createdAt), 'ASC'),
     )
     .map(goal => goal.goalReference)
 }

--- a/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
+++ b/server/interfaces/mappers/personalLearningPlanActionPlanMapper.ts
@@ -10,11 +10,14 @@ import { GoalResponse } from '../educationAndWorkPlanApi/goalResponse'
 const toPersonalLearningPlanActionPlan = (
   apiActionPlanResponse: ActionPlanResponse,
 ): PersonalLearningPlanActionPlan => {
-  const goals = apiActionPlanResponse.goals.map(goal => toPersonalLearningPlanGoal(goal))
+  const goalReferencesInCreationDateOrder = goalReferencesSortedByCreationDate(apiActionPlanResponse.goals)
   return {
     prisonerNumber: apiActionPlanResponse.prisonNumber,
-    goals: [...goals],
-    ...getLastUpdatedAuditFields(goals),
+    goals: apiActionPlanResponse.goals.map((goal: GoalResponse) => {
+      const goalSequenceNumber = goalReferencesInCreationDateOrder.indexOf(goal.goalReference) + 1
+      return toPersonalLearningPlanGoal(goal, goalSequenceNumber)
+    }),
+    ...getLastUpdatedAuditFields(apiActionPlanResponse.goals),
     problemRetrievingData: false,
   }
 }
@@ -25,21 +28,26 @@ const toPersonalLearningPlanActionPlan = (
  * If the specified array of [GoalResponse] is empty then the 3 fields will be returned as `undefined`
  */
 const getLastUpdatedAuditFields = (
-  goals: Array<PersonalLearningPlanGoal>,
+  goals: Array<GoalResponse>,
 ): { updatedBy?: string; updatedByDisplayName?: string; updatedAt?: Date } => {
   if (goals.length === 0) {
     return { updatedBy: undefined, updatedByDisplayName: undefined, updatedAt: undefined }
   }
 
-  const mostRecentGoal = goals.sort(goalComparator)[0]
+  const mostRecentlyUpdatedGoal = [...goals].sort((left: GoalResponse, right: GoalResponse) =>
+    dateComparator(parseISO(left.updatedAt), parseISO(right.updatedAt)),
+  )[0]
   return {
-    updatedBy: mostRecentGoal.updatedBy,
-    updatedByDisplayName: mostRecentGoal.updatedByDisplayName,
-    updatedAt: mostRecentGoal.updatedAt,
+    updatedBy: mostRecentlyUpdatedGoal.updatedBy,
+    updatedByDisplayName: mostRecentlyUpdatedGoal.updatedByDisplayName,
+    updatedAt: parseISO(mostRecentlyUpdatedGoal.updatedAt),
   }
 }
 
-const toPersonalLearningPlanGoal = (apiGoalResponse: GoalResponse): PersonalLearningPlanGoal => {
+const toPersonalLearningPlanGoal = (
+  apiGoalResponse: GoalResponse,
+  goalSequenceNumber: number,
+): PersonalLearningPlanGoal => {
   return {
     reference: apiGoalResponse.goalReference,
     title: apiGoalResponse.title,
@@ -49,17 +57,31 @@ const toPersonalLearningPlanGoal = (apiGoalResponse: GoalResponse): PersonalLear
     updatedAt: parseISO(apiGoalResponse.updatedAt),
     updatedBy: apiGoalResponse.updatedBy,
     updatedByDisplayName: apiGoalResponse.updatedByDisplayName,
+    sequenceNumber: goalSequenceNumber,
   }
 }
 
-const goalComparator = (left: PersonalLearningPlanGoal, right: PersonalLearningPlanGoal): number => {
-  if (left.updatedAt > right.updatedAt) {
+const dateComparator = (left: Date, right: Date): number => {
+  if (left > right) {
     return -1
   }
-  if (left.updatedAt < right.updatedAt) {
+  if (left < right) {
     return 1
   }
   return 0
+}
+
+/**
+ * Sorts the goals by creation date descending in a non-destructive manner (function arg is pass by reference) and
+ * returns an array of the goal reference numbers.
+ */
+const goalReferencesSortedByCreationDate = (goals: Array<GoalResponse>): Array<string> => {
+  return [...goals]
+    .sort(
+      (left: GoalResponse, right: GoalResponse) =>
+        dateComparator(parseISO(left.createdAt), parseISO(right.createdAt)) * -1,
+    )
+    .map(goal => goal.goalReference)
 }
 
 export default toPersonalLearningPlanActionPlan

--- a/server/interfaces/personalLearningPlanGoals.ts
+++ b/server/interfaces/personalLearningPlanGoals.ts
@@ -27,4 +27,5 @@ export interface PersonalLearningPlanGoal {
   updatedAt: Date
   updatedBy: string
   updatedByDisplayName: string
+  sequenceNumber: number
 }

--- a/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
@@ -3,8 +3,7 @@
 <div data-qa="plp-vc2-goals">
   <p class="govuk-body" data-qa="goals-info-text">The careers information, advice and guidance (CIAG) team set these goals. They do not include sentence plan targets.</p>
   {% for goal in personalLearningPlanActionPlan.goals %}
-    {% set goalLoop = loop %} 
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goalLoop.index }}</h3>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
       <p class="govuk-body">{{ goal.title }}</p>
     </div>

--- a/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
@@ -3,8 +3,7 @@
 <div data-qa="plp-goals">
   <p class="govuk-body" data-qa="goals-info-text">The careers information, advice and guidance (CIAG) team set these goals. They do not include sentence plan targets.</p>
   {% for goal in personalLearningPlanActionPlan.goals %}
-    {% set goalLoop = loop %} 
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goalLoop.index }}</h3>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
       <p class="govuk-body">{{ goal.title }}</p>
     </div>


### PR DESCRIPTION
This PR sets the PLP Goal numbering on the W&S tab based on goal creation date rather than loop index.

![Screenshot 2024-02-13 at 16 43 38](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/94835226/62a11264-2d13-479f-8d4f-a16f61d0be16)
