### PR TITLE
RR-643 - Add nunjucks filter to render multiline text; use in rendering of Goals on W&S tab

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -141,4 +141,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('formatName', formatName)
   njkEnv.addFilter('toCsraAssessmentSummaryList', mapCsraReviewToSummaryList)
   njkEnv.addFilter('toCsraQuestionsSummaryList', mapCsraQuestionsToSummaryList)
+
+  njkEnv.addFilter('formatMultilineText', njkEnv.getFilter('nl2br')) // Use the inbuilt `nl2br` filter, but reference it as `formatMultilineText` in the nunjucks templates because it's a better name
 }

--- a/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
@@ -5,7 +5,7 @@
   {% for goal in personalLearningPlanActionPlan.goals %}
     <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
-      <p class="govuk-body">{{ goal.title }}</p>
+      <p class="govuk-body">{{ goal.title | formatMultilineText | safe }}</p>
     </div>
   {% endfor %}
   {% if canEditEducationWorkPlan %}

--- a/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
@@ -5,7 +5,7 @@
   {% for goal in personalLearningPlanActionPlan.goals %}
     <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
-      <p class="govuk-body">{{ goal.title }}</p>
+      <p class="govuk-body">{{ goal.title | formatMultilineText | safe }}</p>
     </div>
   {% endfor %}
   {% if canEditEducationWorkPlan %}


### PR DESCRIPTION
This PR changes the W&S tab when rendering PLP Goals, to support multiline text.
It does this in the exact same way that we have already done in PLP, by adding a nunjucks filter called `formatMultilineText` which is basically a pseudonym for the terribly named standard inbuilt [nl2br filter](https://mozilla.github.io/nunjucks/templating.html#nl2br)

It changes this:
![Screenshot 2024-02-20 at 13 29 20](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/94835226/758a137d-7a39-410f-82bc-8354a3935a47)


to this:
![Screenshot 2024-02-20 at 13 28 43](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/94835226/b66919cc-99e1-47d5-a35e-da9a60873508)
