### PR TITLE
RR-707 - Replaced multiline text filter with css

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -35,3 +35,7 @@
   margin-bottom: 10px;
   clear: both;
 }
+
+.app-u-multiline-text {
+  white-space: pre-line;
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -141,6 +141,4 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addFilter('formatName', formatName)
   njkEnv.addFilter('toCsraAssessmentSummaryList', mapCsraReviewToSummaryList)
   njkEnv.addFilter('toCsraQuestionsSummaryList', mapCsraQuestionsToSummaryList)
-
-  njkEnv.addFilter('formatMultilineText', njkEnv.getFilter('nl2br')) // Use the inbuilt `nl2br` filter, but reference it as `formatMultilineText` in the nunjucks templates because it's a better name
 }

--- a/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpAndVc2Goals.njk
@@ -5,7 +5,7 @@
   {% for goal in personalLearningPlanActionPlan.goals %}
     <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
-      <p class="govuk-body">{{ goal.title | formatMultilineText | safe }}</p>
+      <p class="govuk-body app-u-multiline-text">{{ goal.title }}</p>
     </div>
   {% endfor %}
   {% if canEditEducationWorkPlan %}

--- a/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
+++ b/server/views/partials/workAndSkillsPage/goals/plpGoalsOnly.njk
@@ -5,7 +5,7 @@
   {% for goal in personalLearningPlanActionPlan.goals %}
     <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal {{ goal.sequenceNumber }}</h3>
     <div class="hmpps-goal-container">
-      <p class="govuk-body">{{ goal.title | formatMultilineText | safe }}</p>
+      <p class="govuk-body app-u-multiline-text">{{ goal.title }}</p>
     </div>
   {% endfor %}
   {% if canEditEducationWorkPlan %}


### PR DESCRIPTION
This PR replaces the use of the `formatMultilineText` and `safe` filters with a pure css solution.

The problem with using `formatMultilineText` is that it replaces `\n` with `<br />`. Because the text now contains html that needs to be rendered we needed to use the `safe` filter. And because we are using the `safe` filter on user entered text (eg: Goal title), it means that any html that the user has entered into the field is rendered as markup, rather than being escaped. This is essentially a XSS vulnerability.

![Screenshot 2024-03-11 at 10 09 09](https://github.com/ministryofjustice/hmpps-prisoner-profile/assets/94835226/b0c6e7f1-5365-46c3-a0b4-14d96caafa92)
