### PR TITLE
RR-720 - Fix display of VC2 long term goals on W&S tab

### DIFF
--- a/server/views/partials/workAndSkillsPage/goals/vc2GoalsOnly.njk
+++ b/server/views/partials/workAndSkillsPage/goals/vc2GoalsOnly.njk
@@ -40,7 +40,7 @@
 
   <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Long-term goals</h3>
   <div class="hmpps-goal-container hmpps-goal-container--no-border">
-  {% if (learnerGoals.longTermGoals.length > 0) %}
+  {% if (curiousGoals.longTermGoals.length > 0) %}
       {{ govukSummaryList({
           classes: "hmpps-font-weight-normal",
           rows: curiousGoals.longTermGoals


### PR DESCRIPTION
This PR fixes a problem on the Work & Skills tab in respect of displaying VC2 long term goals.

In our previous work on the W&S tab, we refactored the service classes and data types that populate the Work & Skills tab. Part of this change was to rename the view model property `learnerGoals` to `curiousGoals`. The thinking was that "learner goals" was a little too abstract, and whilst is a VC2/Curious term/data type, you need to know the internals of the Curious API to know this. Given that the scope of our work was to also add the PLP Goals to this page, we decided to rename `learnerGoals` to `curiousGoals`. With the addition of our new `plpGoals` property, it would then be clear which was which 👍 
In doing so we had to update the property name in the nunjucks view templates .... and it looks like we missed one! 😬 

This PR fixes that