### PR TITLE
RR-650 - Addition of prisonService

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -29,6 +29,7 @@ import EducationAndWorkPlanApiRestClient from './educationAndWorkPlanApiClient'
 import RestrictedPatientApiRestClient from './restrictedPatientApiClient'
 import PrisonRegisterStore from './prisonRegisterStore/prisonRegisterStore'
 import CalculateReleaseDatesApiClient from './calculateReleaseDatesApiClient'
+import PrisonRegisterApiRestClient from './prisonRegisterApiClient'
 
 initialiseAppInsights()
 buildAppInsightsClient(applicationInfo())
@@ -57,6 +58,7 @@ export const dataAccess = {
   complexityApiClientBuilder: (token: string) => new ComplexityApiRestClient(token),
   educationAndWorkPlanApiClientBuilder: (token: string) => new EducationAndWorkPlanApiRestClient(token),
   restrictedPatientApiClientBuilder: (token: string) => new RestrictedPatientApiRestClient(token),
+  prisonRegisterApiClientBuilder: (token: string) => new PrisonRegisterApiRestClient(token),
   prisonRegisterStore: new PrisonRegisterStore(createRedisClient()),
   calculateReleaseDatesApiClientBuilder: (token: string) => new CalculateReleaseDatesApiClient(token),
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -26,6 +26,7 @@ import ProbationDocumentsService from './probationDocumentsService'
 import OffencesService from './offencesService'
 import { VisitsService } from './visitsService'
 import AddressService from './addressService'
+import PrisonService from './prisonService'
 
 export const services = () => {
   const {
@@ -45,6 +46,8 @@ export const services = () => {
     manageUsersApiClientBuilder,
     complexityApiClientBuilder,
     calculateReleaseDatesApiClientBuilder,
+    prisonRegisterApiClientBuilder,
+    prisonRegisterStore,
   } = dataAccess
 
   const auditService = AuditService({
@@ -106,6 +109,7 @@ export const services = () => {
     whereaboutsApiClientBuilder,
     caseNotesApiClientBuilder,
   )
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterApiClientBuilder)
 
   return {
     dataAccess,
@@ -134,6 +138,7 @@ export const services = () => {
     offencesService,
     visitsService,
     addressService,
+    prisonService,
   }
 }
 

--- a/server/services/interfaces/prisonService/PrisonServicePrisons.ts
+++ b/server/services/interfaces/prisonService/PrisonServicePrisons.ts
@@ -1,0 +1,10 @@
+/**
+ * Interfaces defining Prison Service view model types.
+ *
+ * These types are a deliberate abstraction from the implementation detail of the REST API that returns the data
+ * so as not to tightly couple the view concerns, including the controller, to any given REST API.
+ */
+export interface Prison {
+  prisonId: string
+  prisonName: string
+}

--- a/server/services/mappers/prisonMapper.test.ts
+++ b/server/services/mappers/prisonMapper.test.ts
@@ -1,0 +1,21 @@
+import toPrison from './prisonMapper'
+import { Prison } from '../interfaces/prisonService/PrisonServicePrisons'
+import { prisonsKeyedByPrisonId } from '../../data/localMockData/prisonRegisterMockData'
+
+describe('prisonMapper', () => {
+  it('should map a PrisonResponse to a Prison', () => {
+    // Given
+    const prisonResponse = prisonsKeyedByPrisonId['MDI']
+
+    const expectedPrison: Prison = {
+      prisonId: 'MDI',
+      prisonName: 'Moorland (HMP & YOI)',
+    }
+
+    // When
+    const actual = toPrison(prisonResponse)
+
+    // Then
+    expect(actual).toEqual(expectedPrison)
+  })
+})

--- a/server/services/mappers/prisonMapper.ts
+++ b/server/services/mappers/prisonMapper.ts
@@ -1,0 +1,9 @@
+import { PrisonDto } from '../../data/interfaces/prisonRegisterApi/prisonRegisterApiTypes'
+import { Prison } from '../interfaces/prisonService/PrisonServicePrisons'
+
+export default function toPrison(prisonDto: PrisonDto): Prison {
+  return {
+    prisonId: prisonDto.prisonId,
+    prisonName: prisonDto.prisonName,
+  }
+}

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,0 +1,197 @@
+import PrisonService from './prisonService'
+import PrisonRegisterStore from '../data/prisonRegisterStore/prisonRegisterStore'
+import PrisonRegisterApiRestClient from '../data/prisonRegisterApiClient'
+import toPrison from './mappers/prisonMapper'
+import { PrisonDto } from '../data/interfaces/prisonRegisterApi/prisonRegisterApiTypes'
+import { prisonsKeyedByPrisonId } from '../data/localMockData/prisonRegisterMockData'
+import { Prison } from './interfaces/prisonService/PrisonServicePrisons'
+
+jest.mock('./mappers/prisonMapper')
+jest.mock('../data/prisonRegisterStore/prisonRegisterStore')
+jest.mock('../data/prisonRegisterApiClient')
+
+describe('prisonService', () => {
+  const mockedPrisonMapper = toPrison as jest.MockedFunction<typeof toPrison>
+
+  const prisonRegisterStore = new PrisonRegisterStore(null) as jest.Mocked<PrisonRegisterStore>
+  const prisonRegisterClient = new PrisonRegisterApiRestClient(null) as jest.Mocked<PrisonRegisterApiRestClient>
+  const prisonRegisterClientBuilder = jest.fn()
+
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClientBuilder)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    prisonRegisterClientBuilder.mockReturnValue(prisonRegisterClient)
+  })
+
+  const allPrisons: Array<PrisonDto> = [
+    prisonsKeyedByPrisonId['AKI'], // not an active prison
+    prisonsKeyedByPrisonId['ASI'], // an active prison
+    prisonsKeyedByPrisonId['MDI'], // an active prison
+  ]
+
+  const activePrisons: Array<PrisonDto> = [
+    prisonsKeyedByPrisonId['ASI'], // an active prison
+    prisonsKeyedByPrisonId['MDI'], // an active prison
+  ]
+
+  describe('getPrisonByPrisonId', () => {
+    it('should get prison by ID given prison has been previously cached', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
+
+      const moorlandPrisonResponse = prisonsKeyedByPrisonId['MDI']
+
+      const expectedPrison: Prison = {
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+      }
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison by ID given prison has not been previously cached', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      const moorlandPrisonResponse = prisonsKeyedByPrisonId['MDI']
+
+      const expectedPrison: Prison = {
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+      }
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+
+    it('should not get prison by ID given prison does not exist in cache or API', async () => {
+      // Given
+      const prisonId = 'some-unknown-prison-id'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      const expectedPrison: Prison = {
+        prisonId,
+        prisonName: undefined,
+      }
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+
+    it('should get prison by ID given retrieving from cache throws an error', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-error')
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      const moorlandPrisonResponse = prisonsKeyedByPrisonId['MDI']
+
+      const expectedPrison: Prison = {
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+      }
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+
+    it('should not get prison by ID given retrieving from cache and API both throw errors', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-cache-error')
+      prisonRegisterClient.getAllPrisons.mockRejectedValue('some-api-error')
+
+      const expectedPrison: Prison = {
+        prisonId,
+        prisonName: undefined,
+      }
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison by ID given prison has not been previously cached but putting in cache throws an error', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+      prisonRegisterStore.setActivePrisons.mockRejectedValue('some-error')
+
+      const expectedPrison: Prison = {
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+      }
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(prisonRegisterClientBuilder).toHaveBeenCalledWith(systemToken)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+  })
+})

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,0 +1,95 @@
+import logger from '../../logger'
+import PrisonRegisterStore from '../data/prisonRegisterStore/prisonRegisterStore'
+import PrisonRegisterApiClient from '../data/interfaces/prisonRegisterApi/PrisonRegisterApiClient'
+import { PrisonDto } from '../data/interfaces/prisonRegisterApi/prisonRegisterApiTypes'
+import { Prison } from './interfaces/prisonService/PrisonServicePrisons'
+import toPrison from './mappers/prisonMapper'
+import { RestClientBuilder } from '../data'
+
+const PRISON_CACHE_TTL_DAYS = 1
+
+/**
+ * Service class to retrieve and cache prisons from the `prison-register` API.
+ */
+export default class PrisonService {
+  constructor(
+    private readonly prisonRegisterStore: PrisonRegisterStore,
+    private readonly prisonRegisterClientBuilder: RestClientBuilder<PrisonRegisterApiClient>,
+  ) {}
+
+  /**
+   * Returns a [Prison] identified by the specified `prisonId`
+   */
+  async getPrisonByPrisonId(prisonId: string, token: string): Promise<Prison> {
+    try {
+      const prisonResponse = await this.getPrison(prisonId, token)
+
+      if (prisonResponse) {
+        return toPrison(prisonResponse)
+      }
+
+      logger.info(`Could not find details for prison ${prisonId}`)
+      return { prisonId, prisonName: undefined }
+    } catch (e) {
+      logger.error(`Error looking up prison ${prisonId}`, e)
+      return { prisonId, prisonName: undefined }
+    }
+  }
+
+  /**
+   * Returns the [PrisonResponse] identified by the specified `prisonId`
+   * Return the object from the cache if it exists in the cache, else seed the cache by calling the API and return the
+   * specified [PrisonResponse]
+   */
+  private async getPrison(prisonId: string, token: string): Promise<PrisonDto> {
+    return (
+      // return prison from the cache
+      (await this.getCachedPrison(prisonId)) ||
+      (async () => {
+        // or retrieve prisons from the API and cache them before returning the one we are looking for
+        const allPrisonResponses = await this.retrieveAndCacheActivePrisons(token)
+        return allPrisonResponses.find(prisonResponse => prisonResponse.prisonId === prisonId)
+      })()
+    )
+  }
+
+  private async getCachedPrison(prisonId: string): Promise<PrisonDto> {
+    try {
+      const allActivePrisons = await this.prisonRegisterStore.getActivePrisons()
+      const cachedPrison = allActivePrisons.find(prisonResponse => prisonResponse.prisonId === prisonId)
+      if (cachedPrison) {
+        return cachedPrison
+      }
+      logger.debug(`Prison ${prisonId} not found in cache`)
+    } catch (ex) {
+      // Looking up the prisons from the cached data store failed for some reason. Return undefined.
+      logger.error('Error retrieving cached prisons', ex)
+    }
+    return undefined
+  }
+
+  /**
+   * Calls the prison-register API to retrieve all prisons, then caches just the active ones in the cache.
+   * Returns an array of active prisons that were cached.
+   */
+  private async retrieveAndCacheActivePrisons(token: string): Promise<Array<PrisonDto>> {
+    logger.info('Retrieving and caching active prisons')
+    let allPrisonResponses: Array<PrisonDto>
+    try {
+      allPrisonResponses = (await this.prisonRegisterClientBuilder(token).getAllPrisons()) || []
+    } catch (ex) {
+      // Retrieving prisons from the API failed. Return an empty array.
+      logger.error('Error retrieving prisons', ex)
+      return []
+    }
+
+    const activePrisons = allPrisonResponses.filter(prison => prison.active === true)
+    try {
+      await this.prisonRegisterStore.setActivePrisons(activePrisons, PRISON_CACHE_TTL_DAYS)
+    } catch (ex) {
+      // Caching prisons retrieved from the API failed. Log a warning but return the prisons anyway. Next time the service is called the caching will be retried.
+      logger.warn('Error caching prisons', ex)
+    }
+    return activePrisons
+  }
+}


### PR DESCRIPTION
This PR adds `prisonService` which will be used to lookup prisons by their prisonID. It uses the `prisonRegisterApiClient` to retrieve data, and the `prisonRegisterStore` to cache it.

The code is based on the same service class in PLP.