### PR TITLE
CDPS-686: Using system token to make case notes API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HMPPS Prisoner Profile
-[![repo standards badge](https://img.shields.io/badge/dynamic/json?color=blue&style=flat&logo=github&label=MoJ%20Compliant&query=%24.result&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-prisoner-profile)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-github-repositories.html#hmpps-prisoner-profile "Link to report")
+[![repo standards badge](https://img.shields.io/badge/endpoint.svg?&style=flat&logo=github&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-template-typescript)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/hmpps-prisoner-profile "Link to report")
 [![Docker Repository on Quay](https://img.shields.io/badge/quay.io-repository-2496ED.svg?logo=docker)](https://quay.io/repository/hmpps/hmpps-prisoner-profile)
 [![CircleCI](https://circleci.com/gh/ministryofjustice/hmpps-prisoner-profile/tree/main.svg?style=svg)](https://circleci.com/gh/ministryofjustice/hmpps-prisoner-profile)
 

--- a/integration_tests/e2e/addCaseNotePage.cy.ts
+++ b/integration_tests/e2e/addCaseNotePage.cy.ts
@@ -14,7 +14,7 @@ context('Add Case Note Page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.setupUserAuth()
-    cy.task('stubGetCaseNotes', 'G6123VU')
+    cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
     cy.task('stubGetCaseNotesUsage', 'G6123VU')
     cy.task('stubGetCaseNoteTypes')
     cy.task('stubGetCaseNoteTypesForUser')
@@ -131,7 +131,7 @@ context('Add Case Note Page', () => {
         cy.task('stubInmateDetail', { bookingId: 1102484 })
         cy.task('stubPrisonerDetail', 'G6123VU')
         cy.task('stubGetCaseNotesUsage', 'G6123VU')
-        cy.task('stubGetCaseNotes', 'G6123VU')
+        cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       })
 
       it('Displays Page Not Found', () => {

--- a/integration_tests/e2e/caseNotesPage.cy.ts
+++ b/integration_tests/e2e/caseNotesPage.cy.ts
@@ -29,7 +29,7 @@ context('Case Notes Page', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       caseNotesPage = visitCaseNotesPage()
     })
 
@@ -90,7 +90,7 @@ context('Case Notes Page', () => {
       })
       cy.task('stubPrisonerDetail', 'A1234BC')
       cy.task('stubGetCaseNotesUsage', 'A1234BC')
-      cy.task('stubGetCaseNotes', 'A1234BC')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'A1234BC' })
       caseNotesPage = visitEmptyCaseNotesPage()
     })
 
@@ -116,7 +116,7 @@ context('Case Notes Page', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       cy.task('stubGetCaseNotesPage2', 'G6123VU')
       caseNotesPage = visitCaseNotesPage()
     })
@@ -141,7 +141,7 @@ context('Case Notes Page', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       cy.task('stubGetCaseNotesSorted', 'G6123VU')
       caseNotesPage = visitCaseNotesPage()
     })
@@ -167,7 +167,7 @@ context('Case Notes Page', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       cy.task('stubGetCaseNotesFiltered', 'G6123VU')
       caseNotesPage = visitCaseNotesPage()
     })
@@ -198,12 +198,12 @@ context('Sensitive Case Notes', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       cy.task('stubGetSensitiveCaseNotesPage', 'G6123VU')
       caseNotesPage = visitCaseNotesPage()
     })
 
-    it('Displays the delete link for the sensitive case note', () => {
+    it('Does not display the delete link for the sensitive case note', () => {
       caseNotesPage.filterType().select('OMIC')
       caseNotesPage.filterApplyButton().click()
 
@@ -226,7 +226,7 @@ context('Sensitive Case Notes', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       cy.task('stubGetSensitiveCaseNotesPage', 'G6123VU')
       caseNotesPage = visitCaseNotesPage()
     })
@@ -252,7 +252,7 @@ context('Incentive slips', () => {
     cy.task('stubInmateDetail', { bookingId: 1102484 })
     cy.task('stubPrisonerDetail', 'G6123VU')
     cy.task('stubGetCaseNotesUsage', 'G6123VU')
-    cy.task('stubGetCaseNotes', 'G6123VU')
+    cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
   })
 
   context('Positive encouragement', () => {
@@ -299,7 +299,7 @@ context('Case Notes Page Not Found', () => {
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
       cy.task('stubGetCaseNotesUsage', 'G6123VU')
-      cy.task('stubGetCaseNotes', 'G6123VU')
+      cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
     })
 
     it('Displays Page Not Found', () => {

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -23,7 +23,6 @@ context('SignIn', () => {
   })
 
   it('User name visible in header', () => {
-    cy.setupUserAuth()
     cy.signIn()
     cy.visit('/prisoner/G6123VU')
     const indexPage = Page.verifyOnPage(IndexPage)

--- a/integration_tests/e2e/updateCaseNotePage.cy.ts
+++ b/integration_tests/e2e/updateCaseNotePage.cy.ts
@@ -13,7 +13,7 @@ context('Update Case Note Page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.setupUserAuth()
-    cy.task('stubGetCaseNotes', 'G6123VU')
+    cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
     cy.task('stubGetCaseNotesUsage', 'G6123VU')
     cy.task('stubGetCaseNoteTypes')
     cy.task('stubGetCaseNoteTypesForUser')
@@ -28,11 +28,12 @@ context('Update Case Note Page', () => {
       cy.setupBannerStubs({ prisonerNumber: 'G6123VU' })
       cy.task('stubInmateDetail', { bookingId: 1102484 })
       cy.task('stubPrisonerDetail', 'G6123VU')
-      caseNotesPage = visitCaseNotesPage()
     })
 
     context('Update a case note', () => {
       beforeEach(() => {
+        caseNotesPage = visitCaseNotesPage()
+
         cy.task('stubGetCaseNote', { prisonerNumber: 'G6123VU', caseNoteId: '123456', isOmic: false })
         caseNotesPage.addMoreDetailsButton().first().click()
         cy.location('pathname').should('eq', '/prisoner/G6123VU/update-case-note/123456')
@@ -55,8 +56,15 @@ context('Update Case Note Page', () => {
 
     context('Updating an OMiC Open Case Note', () => {
       beforeEach(() => {
+        cy.setupUserAuth({ roles: [Role.GlobalSearch, Role.PomUser] })
+        cy.task('stubGetSensitiveCaseNotesPage', 'G6123VU')
+        cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU', includeSensitive: true })
         cy.task('stubGetCaseNote', { prisonerNumber: 'G6123VU', caseNoteId: '123456', isOmic: true })
+
+        caseNotesPage = visitCaseNotesPage()
+
         caseNotesPage.addMoreDetailsButton().first().click()
+
         cy.location('pathname').should('eq', '/prisoner/G6123VU/update-case-note/123456')
         updateCaseNotePage = new UpdateCaseNotePage('Add more details to John Saunders’ case note')
       })
@@ -69,6 +77,7 @@ context('Update Case Note Page', () => {
 
     context('Attempting to update with validation errors', () => {
       beforeEach(() => {
+        caseNotesPage = visitCaseNotesPage()
         cy.task('stubGetCaseNote', { prisonerNumber: 'G6123VU', caseNoteId: '123456', isOmic: false, longText: true })
         caseNotesPage.addMoreDetailsButton().first().click()
         cy.location('pathname').should('eq', '/prisoner/G6123VU/update-case-note/123456')
@@ -110,6 +119,7 @@ context('Update Case Note Page', () => {
         cy.task('stubPrisonerDetail', 'G6123VU')
         cy.task('stubGetCaseNotesUsage', 'G6123VU')
         cy.task('stubGetCaseNotes', 'G6123VU')
+        cy.task('stubGetCaseNotes', { prisonerNumber: 'G6123VU' })
       })
 
       it('Displays Page Not Found', () => {

--- a/integration_tests/mockApis/caseNotesApi.ts
+++ b/integration_tests/mockApis/caseNotesApi.ts
@@ -11,7 +11,13 @@ import {
 import { caseNoteTypesMock } from '../../server/data/localMockData/caseNoteTypesMock'
 
 export default {
-  stubGetCaseNotes: (prisonerNumber: string) => {
+  stubGetCaseNotes: ({
+    prisonerNumber,
+    includeSensitive = false,
+  }: {
+    prisonerNumber: string
+    includeSensitive?: boolean
+  }) => {
     let jsonResp
     if (prisonerNumber === 'G6123VU') {
       jsonResp = pagedCaseNotesMock
@@ -21,7 +27,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/casenotes/case-notes/${prisonerNumber}\\?size=20`,
+        urlPattern: `/casenotes/case-notes/${prisonerNumber}\\?size=20${includeSensitive ? '&includeSensitive=true' : ''}`,
       },
       response: {
         status: 200,
@@ -141,7 +147,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/casenotes/case-notes/${prisonerNumber}\\?size=20&type=OMIC`,
+        urlPattern: `/casenotes/case-notes/${prisonerNumber}\\?size=20&type=OMIC&includeSensitive=true`,
       },
       response: {
         status: 200,

--- a/server/controllers/caseNotesController.test.ts
+++ b/server/controllers/caseNotesController.test.ts
@@ -1,3 +1,4 @@
+import { NextFunction } from 'express'
 import * as headerMappers from '../mappers/headerMappers'
 import CaseNotesController from './caseNotesController'
 import { pagedCaseNotesMock } from '../data/localMockData/pagedCaseNotesMock'
@@ -18,6 +19,7 @@ import UpdateCaseNoteForm from '../data/interfaces/caseNotesApi/UpdateCaseNoteFo
 
 let req: any
 let res: any
+let next: NextFunction
 let controller: any
 
 jest.mock('../services/caseNotesService.ts')
@@ -63,40 +65,75 @@ describe('Case Notes Controller', () => {
       render: jest.fn(),
       redirect: jest.fn(),
     }
+    next = jest.fn()
 
     prisonApiClient = prisonApiClientMock()
     prisonApiClient.getCaseNotesUsage = jest.fn(async () => caseNoteUsageMock)
     controller = new CaseNotesController(() => prisonApiClient, new CaseNotesService(null), auditServiceMock())
   })
 
-  it('should get case notes', async () => {
-    const getCaseNotesSpy = jest.spyOn<any, string>(controller['caseNotesService'], 'get').mockResolvedValue({
-      pagedCaseNotes: pagedCaseNotesMock,
-      listMetadata: null,
-      caseNoteTypes: caseNoteTypesMock,
-      fullName: 'John Middle Names Saunders',
+  describe('displayCaseNotes', () => {
+    it('should get case notes', async () => {
+      const getCaseNotesSpy = jest.spyOn<any, string>(controller['caseNotesService'], 'get').mockResolvedValue({
+        pagedCaseNotes: pagedCaseNotesMock,
+        listMetadata: null,
+        caseNoteTypes: caseNoteTypesMock,
+        fullName: 'John Middle Names Saunders',
+      })
+      const mapSpy = jest.spyOn(headerMappers, 'mapHeaderData')
+      prisonApiClient.getInmateDetail = jest.fn(async () => inmateDetailMock)
+
+      await controller.displayCaseNotes()(req, res)
+
+      expect(prisonApiClient.getCaseNotesUsage).toHaveBeenCalledWith(req.params.prisonerNumber)
+      expect(getCaseNotesSpy).toHaveBeenCalledWith({
+        token: res.locals.clientToken,
+        prisonerData: PrisonerMockDataA,
+        queryParams: {
+          page: 0,
+          sort: 'dateCreated,ASC',
+          type: 'ACP',
+          subType: 'ASSESSMENT',
+          startDate: '01/01/2023',
+          endDate: '02/02/2023',
+        },
+        canViewSensitiveCaseNotes: false,
+        canDeleteSensitiveCaseNotes: true,
+        currentUserDetails: { displayName: 'A Name' },
+      })
+      expect(mapSpy).toHaveBeenCalledWith(PrisonerMockDataA, inmateDetailMock, res.locals.user, 'case-notes')
     })
-    const mapSpy = jest.spyOn(headerMappers, 'mapHeaderData')
-    prisonApiClient.getInmateDetail = jest.fn(async () => inmateDetailMock)
 
-    await controller.displayCaseNotes()(req, res)
+    it('should include sensitive case notes if user has POM role', async () => {
+      const getCaseNotesSpy = jest.spyOn<any, string>(controller['caseNotesService'], 'get').mockResolvedValue({
+        pagedCaseNotes: pagedCaseNotesMock,
+        listMetadata: null,
+        caseNoteTypes: caseNoteTypesMock,
+        fullName: 'John Middle Names Saunders',
+      })
+      jest.spyOn(headerMappers, 'mapHeaderData')
+      prisonApiClient.getInmateDetail = jest.fn(async () => inmateDetailMock)
 
-    expect(prisonApiClient.getCaseNotesUsage).toHaveBeenCalledWith(req.params.prisonerNumber)
-    expect(getCaseNotesSpy).toHaveBeenCalledWith(
-      res.locals.user.token,
-      PrisonerMockDataA,
-      {
-        page: 0,
-        sort: 'dateCreated,ASC',
-        type: 'ACP',
-        subType: 'ASSESSMENT',
-        startDate: '01/01/2023',
-        endDate: '02/02/2023',
-      },
-      true,
-      { displayName: 'A Name' },
-    )
-    expect(mapSpy).toHaveBeenCalledWith(PrisonerMockDataA, inmateDetailMock, res.locals.user, 'case-notes')
+      res.locals.user.userRoles = [Role.PomUser]
+
+      await controller.displayCaseNotes()(req, res)
+
+      expect(getCaseNotesSpy).toHaveBeenCalledWith({
+        token: res.locals.clientToken,
+        prisonerData: PrisonerMockDataA,
+        queryParams: {
+          page: 0,
+          sort: 'dateCreated,ASC',
+          type: 'ACP',
+          subType: 'ASSESSMENT',
+          startDate: '01/01/2023',
+          endDate: '02/02/2023',
+        },
+        canViewSensitiveCaseNotes: true,
+        canDeleteSensitiveCaseNotes: false,
+        currentUserDetails: { displayName: 'A Name' },
+      })
+    })
   })
 
   it('should display add case note page', async () => {
@@ -183,41 +220,98 @@ describe('Case Notes Controller', () => {
         .spyOn<any, string>(controller['caseNotesService'], 'addCaseNote')
         .mockResolvedValue(pagedCaseNotesMock.content[0])
 
-      await controller.post()(req, res)
+      jest
+        .spyOn<any, string>(controller['caseNotesService'], 'getCaseNoteTypesForUser')
+        .mockResolvedValue([{ code: 'REPORTS' }])
 
-      expect(addCaseNoteSpy).toHaveBeenCalledWith(res.locals.user.token, PrisonerMockDataA.prisonerNumber, caseNoteForm)
+      await controller.post()(req, res, next)
+
+      expect(addCaseNoteSpy).toHaveBeenCalledWith(
+        res.locals.clientToken,
+        PrisonerMockDataA.prisonerNumber,
+        caseNoteForm,
+      )
       expect(res.redirect).toHaveBeenCalledWith(
         `${config.serviceUrls.digitalPrison}/prisoner/${PrisonerMockDataA.prisonerNumber}/add-case-note/record-incentive-level`,
       )
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should not permit creation of a case note with wrong type', async () => {
+      const caseNoteForm = {
+        type: 'REPORTS',
+        subType: 'REP_IEP',
+        text: 'Note text',
+        date: '01/01/2023',
+        hours: '16',
+        minutes: '30',
+      }
+      req = {
+        params: {
+          prisonerNumber: PrisonerMockDataA.prisonerNumber,
+        },
+        body: {
+          ...caseNoteForm,
+          refererUrl: 'http://referer',
+        },
+        flash: jest.fn(),
+      }
+
+      jest.spyOn<any, string>(controller['caseNotesService'], 'getCaseNoteTypesForUser').mockResolvedValue([])
+      const addCaseNoteSpy = jest.spyOn<any, string>(controller['caseNotesService'], 'addCaseNote')
+
+      await controller.post()(req, res, next)
+
+      expect(addCaseNoteSpy).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
   })
 
-  it('should display update case note page', async () => {
-    const currentCaseNote = pagedCaseNotesMock.content[0]
-    const currentLength =
-      currentCaseNote.text.length +
-      currentCaseNote.amendments[0].additionalNoteText.length +
-      prisonApiAdditionalCaseNoteTextLength +
-      currentCaseNote.amendments[0].authorUserName.length
-    const getCaseNoteSpy = jest
-      .spyOn<any, string>(controller['caseNotesService'], 'getCaseNote')
-      .mockResolvedValue(currentCaseNote)
-    req.params.caseNoteId = 'abc123'
+  describe('displayUpdateCaseNote', () => {
+    it('should display update case note page', async () => {
+      const currentCaseNote = pagedCaseNotesMock.content[0]
+      const currentLength =
+        currentCaseNote.text.length +
+        currentCaseNote.amendments[0].additionalNoteText.length +
+        prisonApiAdditionalCaseNoteTextLength +
+        currentCaseNote.amendments[0].authorUserName.length
+      const getCaseNoteSpy = jest
+        .spyOn<any, string>(controller['caseNotesService'], 'getCaseNote')
+        .mockResolvedValue(currentCaseNote)
+      req.params.caseNoteId = 'abc123'
 
-    await controller.displayUpdateCaseNote()(req, res)
+      await controller.displayUpdateCaseNote()(req, res)
 
-    expect(getCaseNoteSpy).toHaveBeenCalledWith(res.locals.user.token, req.params.prisonerNumber, req.params.caseNoteId)
-    expect(res.render).toHaveBeenCalledWith('pages/caseNotes/updateCaseNote', {
-      refererUrl: `/prisoner/${PrisonerMockDataA.prisonerNumber}/case-notes`,
-      caseNoteText: '',
-      currentCaseNote,
-      maxLength: 4000 - currentLength - prisonApiAdditionalCaseNoteTextLength - res.locals.user.username.length,
-      isOMICOpen: false,
-      isExternal: false,
-      prisonerDisplayName: 'John Saunders',
-      prisonerNumber: PrisonerMockDataA.prisonerNumber,
-      currentLength,
-      errors: undefined,
+      expect(getCaseNoteSpy).toHaveBeenCalledWith(
+        res.locals.clientToken,
+        req.params.prisonerNumber,
+        req.params.caseNoteId,
+      )
+
+      expect(res.render).toHaveBeenCalledWith('pages/caseNotes/updateCaseNote', {
+        refererUrl: `/prisoner/${PrisonerMockDataA.prisonerNumber}/case-notes`,
+        caseNoteText: '',
+        currentCaseNote,
+        maxLength: 4000 - currentLength - prisonApiAdditionalCaseNoteTextLength - res.locals.user.username.length,
+        isOMICOpen: false,
+        isExternal: false,
+        prisonerDisplayName: 'John Saunders',
+        prisonerNumber: PrisonerMockDataA.prisonerNumber,
+        currentLength,
+        errors: undefined,
+      })
+    })
+
+    it('should not display update page for a sensitive case note when user is not permitted', async () => {
+      res.locals.user.userRoles = []
+      const currentCaseNote = { ...pagedCaseNotesMock.content[0], sensitive: true }
+
+      jest.spyOn<any, string>(controller['caseNotesService'], 'getCaseNote').mockResolvedValue(currentCaseNote)
+
+      await controller.displayUpdateCaseNote()(req, res, next)
+
+      expect(res.render).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
   })
 
@@ -246,15 +340,45 @@ describe('Case Notes Controller', () => {
         .spyOn<any, string>(controller['caseNotesService'], 'updateCaseNote')
         .mockResolvedValue(pagedCaseNotesMock.content[0])
 
+      jest
+        .spyOn<any, string>(controller['caseNotesService'], 'getCaseNote')
+        .mockResolvedValue(pagedCaseNotesMock.content[0])
+
       await controller.postUpdate()(req, res)
 
       expect(updateCaseNoteSpy).toHaveBeenCalledWith(
-        res.locals.user.token,
+        res.locals.clientToken,
         PrisonerMockDataA.prisonerNumber,
         caseNoteId,
         updateCaseNoteForm,
       )
       expect(res.redirect).toHaveBeenCalledWith(`/prisoner/${PrisonerMockDataA.prisonerNumber}/case-notes`)
+    })
+
+    it('should not permit update of sensitive case note when user is not permitted', async () => {
+      res.locals.user.userRoles = []
+      const currentCaseNote = { ...pagedCaseNotesMock.content[0], sensitive: true }
+      req = {
+        params: {
+          prisonerNumber: PrisonerMockDataA.prisonerNumber,
+        },
+        body: {
+          text: 'Note text',
+          isExternal: false,
+          username: 'AB123456',
+          currentLength: 100,
+          refererUrl: 'http://referer',
+        },
+        flash: jest.fn(),
+      }
+
+      const updateCaseNoteSpy = jest.spyOn<any, string>(controller['caseNotesService'], 'updateCaseNote')
+      jest.spyOn<any, string>(controller['caseNotesService'], 'getCaseNote').mockResolvedValue(currentCaseNote)
+
+      await controller.postUpdate()(req, res, next)
+
+      expect(updateCaseNoteSpy).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
     })
   })
 })

--- a/server/controllers/interfaces/OverviewPageData.ts
+++ b/server/controllers/interfaces/OverviewPageData.ts
@@ -8,8 +8,6 @@ export default interface OverviewPageData extends OverviewPage {
   courtCaseSummary: CourtCaseSummary
   overviewActions: HmppsAction[]
   overviewInfoLinks: { text: string; url: string; dataQA: string }[]
-  canView: boolean
-  canAdd: boolean
   prisonerDisplayName: string
   options: {
     showCourtCaseSummary: boolean

--- a/server/controllers/overviewController.ts
+++ b/server/controllers/overviewController.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import { mapHeaderData } from '../mappers/headerMappers'
 import OverviewPageService from '../services/overviewPageService'
-import { canAddCaseNotes, canViewCaseNotes } from '../utils/roleHelpers'
 import Prisoner from '../data/interfaces/prisonerSearchApi/Prisoner'
 import config from '../config'
 import { User } from '../data/hmppsAuthClient'
@@ -78,10 +77,6 @@ export default class OverviewController {
 
     const overviewInfoLinks = this.buildOverviewInfoLinks(prisonerData, pathfinderNominal, socNominal, res.locals.user)
 
-    // Set role based permissions
-    const canView = canViewCaseNotes(res.locals.user, prisonerData)
-    const canAdd = canAddCaseNotes(res.locals.user, prisonerData)
-
     this.auditService
       .sendPageView({
         userId: res.locals.user.username,
@@ -100,8 +95,6 @@ export default class OverviewController {
       ...overviewPageData,
       overviewActions,
       overviewInfoLinks,
-      canView,
-      canAdd,
       courtCaseSummary: mapCourtCaseSummary(
         nextCourtAppearance,
         activeCourtCasesCount,

--- a/server/data/interfaces/caseNotesApi/caseNotesApiClient.ts
+++ b/server/data/interfaces/caseNotesApi/caseNotesApiClient.ts
@@ -1,10 +1,10 @@
-import PagedList, { PagedListQueryParams } from '../prisonApi/PagedList'
+import PagedList, { CaseNotesListQueryParams } from '../prisonApi/PagedList'
 import CaseNoteType from './CaseNoteType'
 import CaseNote from './CaseNote'
 import UpdateCaseNoteForm from './UpdateCaseNoteForm'
 
 export default interface CaseNotesApiClient {
-  getCaseNotes(offenderNumber: string, queryParams: PagedListQueryParams): Promise<PagedList<CaseNote>>
+  getCaseNotes(offenderNumber: string, queryParams: CaseNotesListQueryParams): Promise<PagedList<CaseNote>>
   getCaseNoteTypes(): Promise<CaseNoteType[]>
   getCaseNoteTypesForUser(): Promise<CaseNoteType[]>
   addCaseNote(prisonerNumber: string, caseNote: CaseNote): Promise<CaseNote>

--- a/server/data/interfaces/prisonApi/PagedList.ts
+++ b/server/data/interfaces/prisonApi/PagedList.ts
@@ -54,6 +54,7 @@ export interface CaseNotesListQueryParams extends PagedListQueryParams {
   subType?: string
   startDate?: string
   endDate?: string
+  includeSensitive?: boolean
 }
 
 export interface VisitsListQueryParams extends PagedListQueryParams {

--- a/server/middleware/checkPrisonerInCaseloadMiddleware.test.ts
+++ b/server/middleware/checkPrisonerInCaseloadMiddleware.test.ts
@@ -154,7 +154,7 @@ describe('CheckPrisonerInCaseloadMiddleware', () => {
 
       describe('Given a POM user', () => {
         beforeEach(() => {
-          res.locals.user.userRoles = [Role.PrisonUser, 'POM']
+          res.locals.user.userRoles = [Role.PrisonUser, Role.PomUser]
         })
 
         it('Does not let users view a patient without the supporting prison caseload', async () => {
@@ -318,6 +318,15 @@ describe('CheckPrisonerInCaseloadMiddleware', () => {
           res.locals.user.userRoles = [Role.GlobalSearch]
 
           await checkPrisonerInCaseload()(req, res, next)
+          expectAccessToBeGranted()
+        })
+
+        it('should return next() if user has roles POM and GLOBAL_SEARCH, allowGlobal is false but allowGlobalPom is true', async () => {
+          res.locals.user.userRoles = [Role.PomUser, Role.GlobalSearch]
+
+          setPrisonerData({ prisonId: 'ZZZ' })
+
+          await checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true })(req, res, next)
           expectAccessToBeGranted()
         })
       })

--- a/server/middleware/checkPrisonerInCaseloadMiddleware.ts
+++ b/server/middleware/checkPrisonerInCaseloadMiddleware.ts
@@ -10,6 +10,7 @@ import CaseLoad from '../data/interfaces/prisonApi/CaseLoad'
 
 export default function checkPrisonerInCaseload({
   allowGlobal = true,
+  allowGlobalPom = true,
   allowInactive = true,
   activeCaseloadOnly = false,
 } = {}): RequestHandler {
@@ -36,7 +37,7 @@ export default function checkPrisonerInCaseload({
      * - POM users who have the supporting prison ID in their case loads
      * - Users with the inactive bookings role
      */
-    function authenticateRestictedPatient() {
+    function authenticateRestrictedPatient() {
       return (
         (pomUser && prisonerBelongsToUsersCaseLoad(prisonerData.supportingPrisonId, caseLoads)) || inactiveBookingsUser
       )
@@ -63,7 +64,7 @@ export default function checkPrisonerInCaseload({
         return true
       }
 
-      return allowGlobal && globalSearchUser
+      return (allowGlobal && globalSearchUser) || (allowGlobalPom && pomUser && globalSearchUser)
     }
 
     // Some routes can only be accessed if the prisoner is within your active caseload
@@ -80,7 +81,7 @@ export default function checkPrisonerInCaseload({
     }
 
     if (restrictedPatient) {
-      if (!authenticateRestictedPatient()) {
+      if (!authenticateRestrictedPatient()) {
         return authenticationError(
           'CheckPrisonerInCaseloadMiddleware: Prisoner is restricted patient',
           HmppsStatusCode.RESTRICTED_PATIENT,

--- a/server/routes/caseNotesRouter.ts
+++ b/server/routes/caseNotesRouter.ts
@@ -8,6 +8,7 @@ import { Page } from '../services/auditService'
 import { getRequest, postRequest } from './routerUtils'
 import getPrisonerData from '../middleware/getPrisonerDataMiddleware'
 import { UpdateCaseNoteValidator } from '../validators/updateCaseNoteValidator'
+import checkPrisonerInCaseload from '../middleware/checkPrisonerInCaseloadMiddleware'
 
 export default function caseNotesRouter(services: Services): Router {
   const router = Router()
@@ -24,6 +25,7 @@ export default function caseNotesRouter(services: Services): Router {
     '/prisoner/:prisonerNumber/case-notes',
     auditPageAccessAttempt({ services, page: Page.CaseNotes }),
     getPrisonerData(services),
+    checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true }),
     caseNotesController.displayCaseNotes(),
   )
 
@@ -31,11 +33,15 @@ export default function caseNotesRouter(services: Services): Router {
     '/prisoner/:prisonerNumber/add-case-note',
     auditPageAccessAttempt({ services, page: Page.AddCaseNote }),
     getPrisonerData(services),
+    checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true }),
     caseNotesController.displayAddCaseNote(),
   )
+
   post(
     '/prisoner/:prisonerNumber/add-case-note',
     auditPageAccessAttempt({ services, page: Page.PostAddCaseNote }),
+    getPrisonerData(services),
+    checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true }),
     validationMiddleware(CaseNoteValidator),
     caseNotesController.post(),
   )
@@ -44,11 +50,15 @@ export default function caseNotesRouter(services: Services): Router {
     '/prisoner/:prisonerNumber/update-case-note/:caseNoteId',
     auditPageAccessAttempt({ services, page: Page.UpdateCaseNote }),
     getPrisonerData(services),
+    checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true }),
     caseNotesController.displayUpdateCaseNote(),
   )
+
   post(
     '/prisoner/:prisonerNumber/update-case-note/:caseNoteId',
     auditPageAccessAttempt({ services, page: Page.PostUpdateCaseNote }),
+    getPrisonerData(services),
+    checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true }),
     validationMiddleware(UpdateCaseNoteValidator),
     caseNotesController.postUpdate(),
   )

--- a/server/services/caseNotesService.test.ts
+++ b/server/services/caseNotesService.test.ts
@@ -34,14 +34,36 @@ describe('Case Notes Page', () => {
 
   describe('Get Case Notes', () => {
     it('should call Case Notes API to get case notes', async () => {
-      const caseNotesPageData = await caseNotesService.get('', prisonerData, {}, true, {
-        displayName: 'A Name',
-        name: 'Name',
+      const caseNotesPageData = await caseNotesService.get({
+        token: '',
+        prisonerData,
+        currentUserDetails: {
+          displayName: 'A Name',
+          name: 'Name',
+        },
       })
 
-      expect(caseNotesApiClientSpy.getCaseNoteTypes).toHaveBeenCalled()
-      expect(caseNotesApiClientSpy.getCaseNotes).toHaveBeenCalledWith(prisonerData.prisonerNumber, {})
       expect(caseNotesPageData.fullName).toEqual('John Smith')
+      expect(caseNotesApiClientSpy.getCaseNoteTypes).toHaveBeenCalled()
+      expect(caseNotesApiClientSpy.getCaseNotes).toHaveBeenCalledWith(prisonerData.prisonerNumber, {
+        includeSensitive: false,
+      })
+    })
+
+    it('should allow inclusion of sensitive case notes', async () => {
+      await caseNotesService.get({
+        token: '',
+        prisonerData,
+        currentUserDetails: {
+          displayName: 'A Name',
+          name: 'Name',
+        },
+        canViewSensitiveCaseNotes: true,
+      })
+
+      expect(caseNotesApiClientSpy.getCaseNotes).toHaveBeenCalledWith(prisonerData.prisonerNumber, {
+        includeSensitive: true,
+      })
     })
   })
 
@@ -109,9 +131,13 @@ describe('Case Notes Page', () => {
 
         const {
           pagedCaseNotes: { content },
-        } = await caseNotesService.get('', prisonerData, {}, true, {
-          displayName: 'A Name',
-          name: 'Name',
+        } = await caseNotesService.get({
+          token: '',
+          prisonerData,
+          currentUserDetails: {
+            displayName: 'A Name',
+            name: 'Name',
+          },
         })
 
         expect(content[0].printIncentiveWarningLink).toBeTruthy()

--- a/server/services/caseNotesService.ts
+++ b/server/services/caseNotesService.ts
@@ -38,22 +38,21 @@ export default class CaseNotesService {
     return apiParams
   }
 
-  /**
-   * Handle request for case notes
-   *
-   * @param token
-   * @param prisonerData
-   * @param queryParams
-   * @param canDeleteSensitiveCaseNotes
-   * @param currentUserDetails
-   */
-  public async get(
-    token: string,
-    prisonerData: Prisoner,
-    queryParams: CaseNotesListQueryParams,
-    canDeleteSensitiveCaseNotes: boolean,
-    currentUserDetails: UserDetails,
-  ): Promise<CaseNotesPageData> {
+  public async get({
+    token,
+    prisonerData,
+    queryParams = {},
+    canViewSensitiveCaseNotes = false,
+    canDeleteSensitiveCaseNotes = false,
+    currentUserDetails,
+  }: {
+    token: string
+    prisonerData: Prisoner
+    queryParams?: CaseNotesListQueryParams
+    canViewSensitiveCaseNotes?: boolean
+    canDeleteSensitiveCaseNotes?: boolean
+    currentUserDetails: UserDetails
+  }): Promise<CaseNotesPageData> {
     const sortOptions: SortOption[] = [
       { value: 'creationDateTime,DESC', description: 'Created (most recent)' },
       { value: 'creationDateTime,ASC', description: 'Created (oldest)' },
@@ -69,10 +68,10 @@ export default class CaseNotesService {
     const prisonerFullName = formatName(prisonerData.firstName, prisonerData.middleNames, prisonerData.lastName)
 
     if (!errors.length) {
-      const { content, ...rest } = await caseNotesApiClient.getCaseNotes(
-        prisonerData.prisonerNumber,
-        this.mapToApiParams(queryParams),
-      )
+      const { content, ...rest } = await caseNotesApiClient.getCaseNotes(prisonerData.prisonerNumber, {
+        ...this.mapToApiParams(queryParams),
+        includeSensitive: canViewSensitiveCaseNotes,
+      })
 
       const pagedCaseNotesContent = content?.map((caseNote: CaseNote) => {
         return {


### PR DESCRIPTION
This PR enables us to use the client token to call the `offender-case-notes` API (with the one exception of the getTypesForUser call).

This allows us to drive (and correct) the rules for when users can create / edit / view case notes.

**The following issues are fixed in this PR:**

* When POM users were trying to legitimately create or view OMiC case notes for Restricted Patients, the Prison API part of the chain was rejecting the request because it does not consider the restricted patient's supported prison id when checking user caseload access.

 * We were allowing users with POM and GLOBAL_SEARCH roles to access the case notes of restricted patients who are supported by a prison not in their caseload (https://mojdt.slack.com/archives/C01SNQDC10R/p1712332714758639)