### PR TITLE
Allowed pathfinder user role to refer to pathfinder from the profile

### DIFF
--- a/integration_tests/e2e/overviewPage.cy.ts
+++ b/integration_tests/e2e/overviewPage.cy.ts
@@ -315,6 +315,27 @@ context('Overview Page', () => {
     })
   })
 
+  context('Given the user has PF_LOCAL_READER role', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.setupUserAuth({
+        roles: [Role.PrisonUser, Role.PathfinderLocalReader],
+      })
+    })
+
+    context('Prisoner is not currently in Pathfinder', () => {
+      beforeEach(() => {
+        cy.setupOverviewPageStubs({ prisonerNumber: 'A1234BC', bookingId: 1234567 })
+      })
+
+      it('should not display Refer to Pathfinder link, and not the Pathfinder profile link', () => {
+        const overviewPage = visitOverviewPageAlt()
+        overviewPage.referToPathfinderActionLink().should('not.exist')
+        overviewPage.pathfinderProfileInfoLink().should('not.exist')
+      })
+    })
+  })
+
   context('Given the user has PF_USER role', () => {
     beforeEach(() => {
       cy.task('reset')

--- a/integration_tests/e2e/overviewPage.cy.ts
+++ b/integration_tests/e2e/overviewPage.cy.ts
@@ -328,9 +328,9 @@ context('Overview Page', () => {
         cy.setupOverviewPageStubs({ prisonerNumber: 'A1234BC', bookingId: 1234567 })
       })
 
-      it('should not display Refer to Pathfinder link, and not the Pathfinder profile link', () => {
+      it('should display Refer to Pathfinder link, and not the Pathfinder profile link', () => {
         const overviewPage = visitOverviewPageAlt()
-        overviewPage.referToPathfinderActionLink().should('not.exist')
+        overviewPage.referToPathfinderActionLink().should('exist')
         overviewPage.pathfinderProfileInfoLink().should('not.exist')
       })
     })

--- a/server/controllers/utils/overviewController/buildOverviewActions.test.ts
+++ b/server/controllers/utils/overviewController/buildOverviewActions.test.ts
@@ -172,6 +172,7 @@ describe('buildOverviewActions', () => {
       ${[Role.PathfinderStdPrison]}    | ${undefined}           | ${true}
       ${[Role.PathfinderStdProbation]} | ${undefined}           | ${true}
       ${[Role.PathfinderHQ]}           | ${undefined}           | ${true}
+      ${[Role.PathfinderUser]}         | ${undefined}           | ${true}
       ${[]}                            | ${undefined}           | ${false}
       ${[Role.PathfinderHQ]}           | ${pathfinderNominal}   | ${false}
     `('user with roles: $expected, can see: $visible', ({ roles, pathfinderNominalToUse, visible }) => {

--- a/server/controllers/utils/overviewController/buildOverviewActions.ts
+++ b/server/controllers/utils/overviewController/buildOverviewActions.ts
@@ -90,7 +90,13 @@ export default (
 
   if (
     userHasRoles(
-      [Role.PathfinderApproval, Role.PathfinderStdPrison, Role.PathfinderStdProbation, Role.PathfinderHQ],
+      [
+        Role.PathfinderApproval,
+        Role.PathfinderStdPrison,
+        Role.PathfinderStdProbation,
+        Role.PathfinderHQ,
+        Role.PathfinderUser,
+      ],
       user.userRoles,
     ) &&
     !pathfinderNominal


### PR DESCRIPTION
This PR is for allowing users with the role PATHFINDER_USER to refer prisoners to pathfinder.