### PR TITLE
CDPS-721: Use parameterised paths in app insights

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -23,6 +23,7 @@ import flashMessageMiddleware from './middleware/flashMessageMiddleware'
 import setUpEnvironmentName from './middleware/setUpEnvironmentName'
 import apiErrorMiddleware from './middleware/apiErrorMiddleware'
 import bannerMiddleware from './middleware/bannerMiddleware'
+import { appInsightsMiddleware } from './utils/azureAppInsights'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -31,6 +32,7 @@ export default function createApp(services: Services): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  app.use(appInsightsMiddleware())
   app.use(metricsMiddleware)
   app.use(setUpHealthChecks(services.dataAccess.applicationInfo))
   app.use(setUpWebSecurity())


### PR DESCRIPTION
Marcus Aspin had seen a similar problem with their app responding with 502s that were not visible in app insights.  Turned out it was a memory leak issue due to paths not being normalised correctly for the Prometheus library: https://mojdt.slack.com/archives/C57UPMZLY/p1715763467600349?thread_ts=1715762197.517079&cid=C57UPMZLY

This PR is part 1 of parameterising our paths that are reported (in this case, to app insights).  This will be quite useful because when summarising requests/errors by name, we should get them grouped properly.

Pulled from update to typescript template: https://github.com/ministryofjustice/hmpps-template-typescript/pull/315/files#diff-226c1869e16c3e24e492b3483e64e2c58cca766e43b81632c01fb056ff8f666d
