### PR TITLE
BAVL-256: Use new Book A Video Link API

### DIFF
--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -71,17 +71,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showHideVlbLocations() {
     const appointmentType = appointmentTypeSelect.value
-    if (videoLocationGroup !== null) {
-      if (appointmentType === 'VLB') {
-        appointmentLocationGroup.style.display = 'none'
-        videoLocationGroup.style.display = 'block'
-      } else {
-        appointmentLocationGroup.style.display = 'block'
-        videoLocationGroup.style.display = 'none'
-      }
-
-      getEventsForLocation()
+    if (appointmentType === 'VLB' && videoLocationGroup) {
+      appointmentLocationGroup.style.display = 'none'
+      videoLocationGroup.style.display = 'block'
+    } else {
+      appointmentLocationGroup.style.display = 'block'
+      videoLocationGroup ? videoLocationGroup.style.display = 'none' : null
     }
+
+    getEventsForLocation()
   }
 
   appointmentTypeSelect.addEventListener('change', () => {

--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
   async function getEventsForLocation() {
     const date = appointmentDateInput.value
     const locationId = appointmentLocationGroup.style.display === 'block' && appointmentLocationSelect.value
-    const locationKey = videoLocationGroup.style.display === 'block' && videoLocationSelect.value
+    const locationKey = videoLocationGroup?.style.display === 'block' && videoLocationSelect?.value
 
     const response =
       date && locationId && (await fetch(`/api/get-location-events?date=${date}&locationId=${locationId}`)) ||
@@ -63,6 +63,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function showHideRecurring() {
     const appointmentType = appointmentTypeSelect.value
 
+    console.log(appointmentType)
+
     if (appointmentType === 'VLB') {
       recurringRadios.style.display = 'none'
     } else {
@@ -93,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
   appointmentLocationSelect.addEventListener('change', () => {
     getEventsForLocation()
   })
-  videoLocationSelect.addEventListener('change', () => {
+  videoLocationSelect?.addEventListener('change', () => {
     getEventsForLocation()
   })
   appointmentDateInput.addEventListener('change', () => {

--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -62,9 +62,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showHideRecurring() {
     const appointmentType = appointmentTypeSelect.value
-
-    console.log(appointmentType)
-
     if (appointmentType === 'VLB') {
       recurringRadios.style.display = 'none'
     } else {

--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const appointmentDateInput = document.getElementById('date')
+  const appointmentLocationGroup = document.querySelector('.js-appointment-locations-group')
   const appointmentLocationSelect = document.getElementById('location')
+  const videoLocationGroup = document.querySelector('.js-video-locations-group')
+  const videoLocationSelect = document.querySelector('.js-video-location')
   const appointmentTypeSelect = document.getElementById('appointmentType')
   const recurringRadios = document.querySelector('.js-recurring-radios')
   const appointmentRepeatsSelect = document.getElementById('repeats')
@@ -11,10 +14,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function getEventsForLocation() {
     const date = appointmentDateInput.value
-    const locationId = appointmentLocationSelect.value
+    const locationId = appointmentLocationGroup.style.display === 'block' && appointmentLocationSelect.value
+    const locationKey = videoLocationGroup.style.display === 'block' && videoLocationSelect.value
 
     const response =
-      date && locationId && (await fetch(`/api/get-location-events?date=${date}&locationId=${locationId}`))
+      date && locationId && (await fetch(`/api/get-location-events?date=${date}&locationId=${locationId}`)) ||
+      date && locationKey && (await fetch(`/api/get-location-events?date=${date}&locationKey=${locationKey}`))
 
     if (response?.ok) {
       locationEventsContainer.innerHTML = await response.text()
@@ -65,11 +70,30 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function showHideVlbLocations() {
+    const appointmentType = appointmentTypeSelect.value
+    if (videoLocationGroup !== null) {
+      if (appointmentType === 'VLB') {
+        appointmentLocationGroup.style.display = 'none'
+        videoLocationGroup.style.display = 'block'
+      } else {
+        appointmentLocationGroup.style.display = 'block'
+        videoLocationGroup.style.display = 'none'
+      }
+
+      getEventsForLocation()
+    }
+  }
+
   appointmentTypeSelect.addEventListener('change', () => {
     showHideRecurring()
+    showHideVlbLocations()
   })
 
   appointmentLocationSelect.addEventListener('change', () => {
+    getEventsForLocation()
+  })
+  videoLocationSelect.addEventListener('change', () => {
     getEventsForLocation()
   })
   appointmentDateInput.addEventListener('change', () => {
@@ -95,4 +119,5 @@ document.addEventListener('DOMContentLoaded', () => {
   getEventsForLocation()
   getAppointmentEndDate()
   showHideRecurring()
+  showHideVlbLocations()
 })

--- a/assets/js/prePostAppointment.js
+++ b/assets/js/prePostAppointment.js
@@ -8,10 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function getPrePostEventsForLocation(input, container) {
     const locationId = Number(input.value)
+    const locationKey = input.value
     const date = document.getElementById('date').value
 
     const response =
-      date && locationId && (await fetch(`/api/get-location-events?date=${date}&locationId=${locationId}`))
+      date && locationId && (await fetch(`/api/get-location-events?date=${date}&locationId=${locationId}`)) ||
+      date && locationKey && (await fetch(`/api/get-location-events?date=${date}&locationKey=${locationKey}`))
 
     if (response?.ok) {
       container.innerHTML = await response.text()

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -78,6 +78,7 @@ generic-service:
     COURT_CASES_SUMMARY_ENABLED: "true"
     PRISON_PERSON_API_ENABLED: "true"
     PRISON_PERSON_API_ENABLED_PRISONS: "KMI"
+    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-prisoner-profile-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -77,6 +77,7 @@ generic-service:
     COURT_CASES_SUMMARY_ENABLED: "true"
     PRISON_PERSON_API_ENABLED: "true"
     PRISON_PERSON_API_ENABLED_PRISONS: "KMI"
+    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "false"
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -80,6 +80,7 @@ generic-service:
     COURT_CASES_SUMMARY_ENABLED: "true"
     PRISON_PERSON_API_ENABLED: "false"
     PRISON_PERSON_API_ENABLED_PRISONS: ""
+    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "false"
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/readme/building_and_running.md
+++ b/readme/building_and_running.md
@@ -60,6 +60,7 @@ ACTIVITIES_URL=https://activities-dev.prison.service.justice.gov.uk/activities
 ADJUDICATIONS_UI_URL=https://manage-adjudications-dev.hmpps.service.justice.gov.uk
 ALLOCATION_MANAGER_ENDPOINT_URL=https://dev.moic.service.justice.gov.uk
 APPOINTMENTS_URL=https://activities-dev.prison.service.justice.gov.uk/appointments
+BOOK_A_VIDEO_LINK_API_URL=https://book-a-video-link-api-dev.prison.service.justice.gov.uk
 CALCULATE_RELEASE_DATES_UI_URL=https://calculate-release-dates-dev.hmpps.service.justice.gov.uk
 CASE_NOTES_API_URL=https://dev.offender-case-notes.service.justice.gov.uk
 COMPONENT_API_LATEST=true

--- a/server/config.ts
+++ b/server/config.ts
@@ -134,6 +134,14 @@ export default {
       },
       agent: new AgentConfig(Number(get('WHEREABOUTS_API_URL_TIMEOUT_DEADLINE', 20000))),
     },
+    bookAVideoLinkApi: {
+      url: get('BOOK_A_VIDEO_LINK_API_URL', 'http://localhost:8082', requiredInProduction),
+      timeout: {
+        response: Number(get('BOOK_A_VIDEO_LINK_API_TIMEOUT_SECONDS', 20000)),
+        deadline: Number(get('BOOK_A_VIDEO_LINK_API_TIMEOUT_SECONDS', 20000)),
+      },
+      agent: new AgentConfig(Number(get('BOOK_A_VIDEO_LINK_API_TIMEOUT_DEADLINE', 20000))),
+    },
     caseNotesApi: {
       url: get('CASE_NOTES_API_URL', 'http://localhost:8082', requiredInProduction),
       timeout: {
@@ -355,6 +363,7 @@ export default {
     ),
     useOfForceDisabledPrisons: get('USE_OF_FORCE_DISABLED_PRISONS', [], requiredInProduction) as string[],
     profileAddAppointmentEnabled: toBoolean(get('PROFILE_ADD_APPOINTMENT_ENABLED', 'false')),
+    bookAVideoLinkEnabled: toBoolean(get('BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED', 'false')),
     courCasesSummaryEnabled: toBoolean(get('COURT_CASES_SUMMARY_ENABLED', 'false')),
     prisonPersonApiEnabled: toBoolean(get('PRISON_PERSON_API_ENABLED', 'false')),
     prisonPersonApiEnabledPrisons: get('PRISON_PERSON_API_ENABLED_PRISONS', []),

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -159,7 +159,7 @@ export default class AppointmentController {
         const appointmentsToCreate: AppointmentDefaults = {
           bookingId,
           appointmentType,
-          locationId: appointmentType === 'VLB' && config.featureToggles.bookAVideoLinkEnabled ? vlbLocation : location,
+          locationId: Number(location),
           startTime,
           endTime,
           comment: comments,
@@ -321,7 +321,7 @@ export default class AppointmentController {
         appointmentFlash[0] as unknown as PrePostAppointmentDetails
 
       const location = config.featureToggles.bookAVideoLinkEnabled
-        ? (locations as VideoLinkLocation[]).find(loc => loc.key === appointmentDefaults.locationId)?.description
+        ? (locations as VideoLinkLocation[]).find(loc => loc.key === appointmentForm.location)?.description
         : (locations as Location[]).find(loc => loc.locationId === +appointmentDefaults.locationId)?.userDescription
 
       const hearingTypes = config.featureToggles.bookAVideoLinkEnabled
@@ -530,7 +530,8 @@ export default class AppointmentController {
       if (!appointmentFlash?.length) {
         return new ServerError('PrePostAppointmentDetails not found in request')
       }
-      const { appointmentDefaults, formValues } = appointmentFlash[0] as unknown as PrePostAppointmentDetails
+      const { appointmentDefaults, appointmentForm, formValues } =
+        appointmentFlash[0] as unknown as PrePostAppointmentDetails
 
       const { firstName, lastName, cellLocation, prisonId } = req.middleware.prisonerData
       const prisonerName = formatName(firstName, undefined, lastName, { style: NameFormatStyle.firstLast })
@@ -542,7 +543,7 @@ export default class AppointmentController {
       ])
 
       const location = config.featureToggles.bookAVideoLinkEnabled
-        ? (locations as VideoLinkLocation[]).find(loc => loc.key === appointmentDefaults.locationId)?.description
+        ? (locations as VideoLinkLocation[]).find(loc => loc.key === appointmentForm.location)?.description
         : (locations as Location[]).find(loc => loc.locationId === +appointmentDefaults.locationId)?.userDescription
 
       const preLocation = config.featureToggles.bookAVideoLinkEnabled

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -455,7 +455,7 @@ export default class AppointmentController {
                       : undefined,
                     {
                       type: 'VLB_COURT_MAIN',
-                      locationKey: appointmentDefaults.locationId,
+                      locationKey: appointmentForm.location,
                       date: formatDateISO(parseDate(appointmentForm.date)),
                       startTime: timeFormat(appointmentDefaults.startTime),
                       endTime: timeFormat(appointmentDefaults.endTime),

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -138,7 +138,7 @@ export default class AppointmentController {
 
       const appointmentForm: AppointmentForm = {
         appointmentType,
-        location: appointmentType === 'VLB' ? vlbLocation : location,
+        location: appointmentType === 'VLB' && config.featureToggles.bookAVideoLinkEnabled ? vlbLocation : location,
         date,
         startTimeHours,
         startTimeMinutes,
@@ -159,7 +159,7 @@ export default class AppointmentController {
         const appointmentsToCreate: AppointmentDefaults = {
           bookingId,
           appointmentType,
-          locationId: appointmentType === 'VLB' ? vlbLocation : location,
+          locationId: appointmentType === 'VLB' && config.featureToggles.bookAVideoLinkEnabled ? vlbLocation : location,
           startTime,
           endTime,
           comment: comments,

--- a/server/controllers/appointmentsController.test.ts
+++ b/server/controllers/appointmentsController.test.ts
@@ -186,6 +186,8 @@ describe('Appointments Controller', () => {
       },
       refererUrl: `/prisoner/${PrisonerMockDataA.prisonerNumber}`,
       errors: undefined,
+      bookAVideoLinkEnabled: false,
+      vlbLocations: [],
     })
   })
 

--- a/server/controllers/appointmentsController.test.ts
+++ b/server/controllers/appointmentsController.test.ts
@@ -107,6 +107,7 @@ describe('Appointments Controller', () => {
     null,
     null,
     null,
+    null,
   ) as jest.Mocked<AppointmentService>
   const prisonerSearchService: PrisonerSearchService = new PrisonerSearchService(
     null,

--- a/server/data/bookAVideoLinkApiClient.test.ts
+++ b/server/data/bookAVideoLinkApiClient.test.ts
@@ -1,0 +1,70 @@
+import nock from 'nock'
+import config from '../config'
+import { BookAVideoLinkApiClient } from './interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient'
+import BookAVideoLinkRestApiClient from './bookAVideoLinkApiClient'
+import CreateVideoBookingRequest from './interfaces/bookAVideoLinkApi/CreateVideoBookingRequest'
+
+const token = { access_token: 'token-1', expires_in: 300 }
+
+describe('bookAVideoLinkApiClient', () => {
+  let fakeBookAVideoLinkApi: nock.Scope
+  let bookAVideoLinkApiClient: BookAVideoLinkApiClient
+
+  beforeEach(() => {
+    fakeBookAVideoLinkApi = nock(config.apis.bookAVideoLinkApi.url)
+    bookAVideoLinkApiClient = new BookAVideoLinkRestApiClient(token.access_token)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  const mockSuccessfulBookAVideoLinkApiCall = <TReturnData>(url: string, returnData: TReturnData) => {
+    fakeBookAVideoLinkApi.get(url).matchHeader('authorization', `Bearer ${token.access_token}`).reply(200, returnData)
+  }
+  const mockSuccessfulBookAVideoLinkApiPost = <TReturnData>(url: string, body: any, returnData: TReturnData) => {
+    fakeBookAVideoLinkApi
+      .post(url, body)
+      .matchHeader('authorization', `Bearer ${token.access_token}`)
+      .reply(200, returnData)
+  }
+
+  describe('addVideoLinkBooking', () => {
+    it('should post a video link booking', async () => {
+      mockSuccessfulBookAVideoLinkApiPost('/video-link-booking', { bookingType: 'COURT' }, 1)
+
+      const output = await bookAVideoLinkApiClient.addVideoLinkBooking({
+        bookingType: 'COURT',
+      } as CreateVideoBookingRequest)
+      expect(output).toEqual(1)
+    })
+  })
+
+  describe('getVideoLocations', () => {
+    it('should return data from the API', async () => {
+      mockSuccessfulBookAVideoLinkApiCall('/prisons/CODE/locations?videoLinkOnly=true', [{ description: 'VIDEO_LINK' }])
+
+      const output = await bookAVideoLinkApiClient.getVideoLocations('CODE')
+      expect(output).toEqual([{ description: 'VIDEO_LINK' }])
+    })
+  })
+
+  describe('getCourts', () => {
+    it('should return data from the API', async () => {
+      mockSuccessfulBookAVideoLinkApiCall('/courts?enabledOnly=false', [{ description: 'COURT' }])
+
+      const output = await bookAVideoLinkApiClient.getCourts()
+      expect(output).toEqual([{ description: 'COURT' }])
+    })
+  })
+
+  describe('getCourtHearingTypes', () => {
+    it('should return data from the API', async () => {
+      mockSuccessfulBookAVideoLinkApiCall('/reference-codes/group/COURT_HEARING_TYPE', [{ description: 'APPEAL' }])
+
+      const output = await bookAVideoLinkApiClient.getCourtHearingTypes()
+      expect(output).toEqual([{ description: 'APPEAL' }])
+    })
+  })
+})

--- a/server/data/bookAVideoLinkApiClient.ts
+++ b/server/data/bookAVideoLinkApiClient.ts
@@ -1,0 +1,38 @@
+import RestClient from './restClient'
+import config from '../config'
+import { BookAVideoLinkApiClient } from './interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient'
+import CreateVideoBookingRequest from './interfaces/bookAVideoLinkApi/CreateVideoBookingRequest'
+import { mapToQueryString } from '../utils/utils'
+import Location from './interfaces/bookAVideoLinkApi/Location'
+import Court from './interfaces/bookAVideoLinkApi/Court'
+import ReferenceCode from './interfaces/bookAVideoLinkApi/ReferenceCode'
+
+export default class BookAVideoLinkRestApiClient implements BookAVideoLinkApiClient {
+  private readonly restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('Book A Video Link API', config.apis.bookAVideoLinkApi, token)
+  }
+
+  async addVideoLinkBooking(videoLinkBooking: CreateVideoBookingRequest): Promise<number> {
+    return this.restClient.post<number>({ path: '/video-link-booking', data: videoLinkBooking })
+  }
+
+  async getVideoLocations(prisonCode: string): Promise<Location[]> {
+    return this.restClient.get({
+      path: `/prisons/${prisonCode}/locations`,
+      query: mapToQueryString({ videoLinkOnly: true }),
+    })
+  }
+
+  async getCourts(): Promise<Court[]> {
+    return this.restClient.get({
+      path: `/courts`,
+      query: mapToQueryString({ enabledOnly: false }),
+    })
+  }
+
+  async getCourtHearingTypes(): Promise<ReferenceCode[]> {
+    return this.restClient.get({ path: `/reference-codes/group/COURT_HEARING_TYPE` })
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -35,6 +35,7 @@ import AlertsApiRestClient from './alertsApiClient'
 import RedisFeatureToggleStore from './featureToggleStore/redisFeatureToggleStore'
 import InMemoryFeatureToggleStore from './featureToggleStore/inMemoryFeatureToggleStore'
 import PrisonPersonApiRestClient from './prisonPersonApiClient'
+import BookAVideoLinkRestApiClient from './bookAVideoLinkApiClient'
 
 initialiseAppInsights()
 buildAppInsightsClient(applicationInfo())
@@ -58,6 +59,7 @@ export const dataAccess = {
   ),
   nonAssociationsApiClientBuilder: (token: string) => new NonAssociationsApiRestClient(token),
   whereaboutsApiClientBuilder: (token: string) => new WhereaboutsRestApiClient(token),
+  bookAVideoLinkApiClientBuilder: (token: string) => new BookAVideoLinkRestApiClient(token),
   prisonerProfileDeliusApiClientBuilder: (token: string) => new PrisonerProfileDeliusApiRestClient(token),
   manageUsersApiClientBuilder: (token: string) => new ManageUsersApiRestClient(token),
   complexityApiClientBuilder: (token: string) => new ComplexityApiRestClient(token),

--- a/server/data/interfaces/bookAVideoLinkApi/Court.ts
+++ b/server/data/interfaces/bookAVideoLinkApi/Court.ts
@@ -1,0 +1,7 @@
+export default interface Court {
+  courtId: number
+  code: string
+  description: string
+  enabled: boolean
+  notes?: string
+}

--- a/server/data/interfaces/bookAVideoLinkApi/CreateVideoBookingRequest.ts
+++ b/server/data/interfaces/bookAVideoLinkApi/CreateVideoBookingRequest.ts
@@ -1,0 +1,24 @@
+export default interface CreateVideoBookingRequest {
+  bookingType: 'COURT' | 'PROBATION'
+  prisoners: PrisonerDetails[]
+  courtCode?: string
+  courtHearingType?: string
+  probationTeamCode?: string
+  probationMeetingType?: string
+  comments?: string
+  videoLinkUrl?: string
+}
+
+interface PrisonerDetails {
+  prisonCode: string
+  prisonerNumber: string
+  appointments: Appointment[]
+}
+
+interface Appointment {
+  type: 'VLB_COURT_PRE' | 'VLB_COURT_MAIN' | 'VLB_COURT_POST'
+  locationKey: string
+  date: string
+  startTime: string
+  endTime: string
+}

--- a/server/data/interfaces/bookAVideoLinkApi/Location.ts
+++ b/server/data/interfaces/bookAVideoLinkApi/Location.ts
@@ -1,0 +1,5 @@
+export default interface Location {
+  key: string
+  description?: string
+  enabled: boolean
+}

--- a/server/data/interfaces/bookAVideoLinkApi/ReferenceCode.ts
+++ b/server/data/interfaces/bookAVideoLinkApi/ReferenceCode.ts
@@ -1,0 +1,6 @@
+export default interface ReferenceCode {
+  referenceCodeId: number
+  groupCode: string
+  code: string
+  description?: string
+}

--- a/server/data/interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient.ts
+++ b/server/data/interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient.ts
@@ -1,0 +1,11 @@
+import CreateVideoBookingRequest from './CreateVideoBookingRequest'
+import Location from './Location'
+import Court from './Court'
+import ReferenceCode from './ReferenceCode'
+
+export interface BookAVideoLinkApiClient {
+  addVideoLinkBooking(videoLinkBooking: CreateVideoBookingRequest): Promise<number>
+  getVideoLocations(prisonCode: string): Promise<Location[]>
+  getCourts(): Promise<Court[]>
+  getCourtHearingTypes(): Promise<ReferenceCode[]>
+}

--- a/server/data/interfaces/prisonApi/prisonApiClient.ts
+++ b/server/data/interfaces/prisonApi/prisonApiClient.ts
@@ -206,6 +206,7 @@ export interface PrisonApiClient {
   getExternalTransfers(offenderNumbers: string[], agencyId: string, date: string): Promise<PrisonerSchedule[]>
 
   getLocation(locationId: number): Promise<Location>
+  getLocationByKey(locationKey: string): Promise<Location>
 
   getActivitiesAtLocation(
     locationId: number,

--- a/server/data/interfaces/whereaboutsApi/Appointment.ts
+++ b/server/data/interfaces/whereaboutsApi/Appointment.ts
@@ -33,7 +33,7 @@ export interface AppointmentForm {
 export interface AppointmentDefaults {
   bookingId: number
   appointmentType: string
-  locationId: string
+  locationId: number
   startTime: string
   endTime: string
   comment?: string

--- a/server/data/interfaces/whereaboutsApi/Appointment.ts
+++ b/server/data/interfaces/whereaboutsApi/Appointment.ts
@@ -33,7 +33,7 @@ export interface AppointmentForm {
 export interface AppointmentDefaults {
   bookingId: number
   appointmentType: string
-  locationId: number
+  locationId: string
   startTime: string
   endTime: string
   comment?: string
@@ -49,11 +49,12 @@ export interface PrePostAppointmentDetails {
   // PrePost Form values
   formValues?: {
     preAppointment?: string
-    preAppointmentLocation?: number
+    preAppointmentLocation?: string
     postAppointment?: string
-    postAppointmentLocation?: number
+    postAppointmentLocation?: string
     court?: string
     otherCourt?: string
+    hearingType?: string
   }
 }
 

--- a/server/data/localMockData/appointmentMock.ts
+++ b/server/data/localMockData/appointmentMock.ts
@@ -2,7 +2,7 @@ import { AppointmentDefaults } from '../interfaces/whereaboutsApi/Appointment'
 
 export const appointmentMock: AppointmentDefaults = {
   bookingId: 1,
-  locationId: 1,
+  locationId: '1',
   appointmentType: 'CANT',
   comment: 'Comment',
   startTime: '2023-01-01T12:34:56',

--- a/server/data/localMockData/appointmentMock.ts
+++ b/server/data/localMockData/appointmentMock.ts
@@ -2,7 +2,7 @@ import { AppointmentDefaults } from '../interfaces/whereaboutsApi/Appointment'
 
 export const appointmentMock: AppointmentDefaults = {
   bookingId: 1,
-  locationId: '1',
+  locationId: 1,
   appointmentType: 'CANT',
   comment: 'Comment',
   startTime: '2023-01-01T12:34:56',

--- a/server/data/localMockData/courtHearingsMock.ts
+++ b/server/data/localMockData/courtHearingsMock.ts
@@ -1,4 +1,5 @@
 import { CourtHearing } from '../interfaces/prisonApi/CourtCase'
+import ReferenceCode from '../interfaces/bookAVideoLinkApi/ReferenceCode'
 
 export const CourtHearingsMock: CourtHearing[] = [
   {
@@ -75,5 +76,14 @@ export const CourtHearingsMockA: CourtHearing[] = [
       active: true,
       courtType: 'CC',
     },
+  },
+]
+
+export const courtHearingTypes: ReferenceCode[] = [
+  {
+    referenceCodeId: 1,
+    groupCode: 'COURT_HEARING_TYPE',
+    code: 'APPEAL',
+    description: 'Appeal',
   },
 ]

--- a/server/data/localMockData/courtHearingsMock.ts
+++ b/server/data/localMockData/courtHearingsMock.ts
@@ -1,5 +1,6 @@
 import { CourtHearing } from '../interfaces/prisonApi/CourtCase'
 import ReferenceCode from '../interfaces/bookAVideoLinkApi/ReferenceCode'
+import { SelectOption } from '../../utils/utils'
 
 export const CourtHearingsMock: CourtHearing[] = [
   {
@@ -85,5 +86,12 @@ export const courtHearingTypes: ReferenceCode[] = [
     groupCode: 'COURT_HEARING_TYPE',
     code: 'APPEAL',
     description: 'Appeal',
+  },
+]
+
+export const courtHearingTypesSelectOptions: SelectOption[] = [
+  {
+    value: 'APPEAL',
+    text: 'Appeal',
   },
 ]

--- a/server/data/localMockData/courtLocationsMock.ts
+++ b/server/data/localMockData/courtLocationsMock.ts
@@ -38,3 +38,14 @@ export const courtLocationsSelectOptionsMock: SelectOption[] = [
     text: 'Barnsley Court',
   },
 ]
+
+export const courtLocationsSelectOptionsMockBavl: SelectOption[] = [
+  {
+    value: 'ABC',
+    text: 'Leeds Court',
+  },
+  {
+    value: 'DEF',
+    text: 'Barnsley Court',
+  },
+]

--- a/server/data/localMockData/courtLocationsMock.ts
+++ b/server/data/localMockData/courtLocationsMock.ts
@@ -1,5 +1,6 @@
 import CourtLocation from '../interfaces/whereaboutsApi/CourtLocation'
 import { SelectOption } from '../../utils/utils'
+import Court from '../interfaces/bookAVideoLinkApi/Court'
 
 export const courtLocationsMock: CourtLocation[] = [
   {
@@ -9,6 +10,21 @@ export const courtLocationsMock: CourtLocation[] = [
   {
     id: 'DEF',
     name: 'Barnsley Court',
+  },
+]
+
+export const courtLocationsMockBavl: Court[] = [
+  {
+    courtId: 1,
+    code: 'ABC',
+    description: 'Leeds Court',
+    enabled: true,
+  },
+  {
+    courtId: 2,
+    code: 'DEF',
+    description: 'Barnsley Court',
+    enabled: true,
   },
 ]
 

--- a/server/data/localMockData/locationsMock.ts
+++ b/server/data/localMockData/locationsMock.ts
@@ -28,7 +28,7 @@ export const locationsMock: Location[] = [
 export const locationsMockBavl: VideoLocation[] = [
   {
     key: 'VIDEO_LINK_ROOM',
-    description: 'VIDEO_LINK_ROOM',
+    description: 'Video Link Room',
     enabled: true,
   },
 ]
@@ -41,5 +41,12 @@ export const locationsSelectOptionsMock: SelectOption[] = [
   {
     value: 26152,
     text: 'Chapel',
+  },
+]
+
+export const locationsSelectOptionsMockBavl: SelectOption[] = [
+  {
+    value: 'VIDEO_LINK_ROOM',
+    text: 'Video Link Room',
   },
 ]

--- a/server/data/localMockData/locationsMock.ts
+++ b/server/data/localMockData/locationsMock.ts
@@ -1,4 +1,5 @@
 import Location from '../interfaces/prisonApi/Location'
+import VideoLocation from '../interfaces/bookAVideoLinkApi/Location'
 import { SelectOption } from '../../utils/utils'
 
 export const locationsMock: Location[] = [
@@ -21,6 +22,14 @@ export const locationsMock: Location[] = [
     currentOccupancy: 0,
     locationPrefix: 'MDI-PROG_ACT-CHAP',
     userDescription: 'Chapel',
+  },
+]
+
+export const locationsMockBavl: VideoLocation[] = [
+  {
+    key: 'VIDEO_LINK_ROOM',
+    description: 'VIDEO_LINK_ROOM',
+    enabled: true,
   },
 ]
 

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -559,6 +559,14 @@ describe('prisonApiClient', () => {
     })
   })
 
+  describe('getLocationByKey', () => {
+    it('Should return data from the API', async () => {
+      mockSuccessfulPrisonApiCall(`/api/locations/code/CODE`, locationsMock[0])
+      const output = await prisonApiClient.getLocationByKey('CODE')
+      expect(output).toEqual(locationsMock[0])
+    })
+  })
+
   describe('getActivitiesAtLocation', () => {
     it('Should return data from the API', async () => {
       const locationId = 27000

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -462,6 +462,10 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     return this.restClient.get<Location>({ path: `/api/locations/${locationId}` })
   }
 
+  async getLocationByKey(locationKey: string): Promise<Location> {
+    return this.restClient.get<Location>({ path: `/api/locations/code/${locationKey}` })
+  }
+
   async getActivitiesAtLocation(
     locationId: number,
     date: string,

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -1,3 +1,4 @@
+import { Promise } from 'cypress/types/cy-bluebird'
 import AppointmentService from './appointmentService'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import { WhereaboutsApiClient } from '../data/interfaces/whereaboutsApi/whereaboutsApiClient'
@@ -12,6 +13,8 @@ import { courtEventPrisonerSchedulesMock, prisonerSchedulesMock } from '../data/
 import AgenciesMock from '../data/localMockData/agenciesDetails'
 import { ManageUsersApiClient } from '../data/interfaces/manageUsersApi/manageUsersApiClient'
 import { userEmailDataMock } from '../data/localMockData/userEmailDataMock'
+import { BookAVideoLinkApiClient } from '../data/interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient'
+import CreateVideoBookingRequest from '../data/interfaces/bookAVideoLinkApi/CreateVideoBookingRequest'
 
 jest.mock('../data/prisonApiClient')
 jest.mock('../data/whereaboutsClient')
@@ -21,6 +24,7 @@ describe('Appointment Service', () => {
   let prisonApiClient: PrisonApiClient
   let whereaboutsApiClient: WhereaboutsApiClient
   let manageUsersApiClient: ManageUsersApiClient
+  let bookAVideoLinkApiClient: BookAVideoLinkApiClient
 
   beforeEach(() => {
     prisonApiClient = {
@@ -48,10 +52,17 @@ describe('Appointment Service', () => {
     manageUsersApiClient = {
       getUserEmail: jest.fn(async () => userEmailDataMock),
     }
+    bookAVideoLinkApiClient = {
+      addVideoLinkBooking: jest.fn(),
+      getVideoLocations: jest.fn(),
+      getCourts: jest.fn(),
+      getCourtHearingTypes: jest.fn(),
+    }
     appointmentService = new AppointmentService(
       () => prisonApiClient,
       () => whereaboutsApiClient,
       () => manageUsersApiClient,
+      () => bookAVideoLinkApiClient,
     )
   })
 

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -1,4 +1,3 @@
-import { Promise } from 'cypress/types/cy-bluebird'
 import AppointmentService from './appointmentService'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import { WhereaboutsApiClient } from '../data/interfaces/whereaboutsApi/whereaboutsApiClient'
@@ -14,7 +13,6 @@ import AgenciesMock from '../data/localMockData/agenciesDetails'
 import { ManageUsersApiClient } from '../data/interfaces/manageUsersApi/manageUsersApiClient'
 import { userEmailDataMock } from '../data/localMockData/userEmailDataMock'
 import { BookAVideoLinkApiClient } from '../data/interfaces/bookAVideoLinkApi/bookAVideoLinkApiClient'
-import CreateVideoBookingRequest from '../data/interfaces/bookAVideoLinkApi/CreateVideoBookingRequest'
 
 jest.mock('../data/prisonApiClient')
 jest.mock('../data/whereaboutsClient')

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -48,6 +48,7 @@ export const services = () => {
     whereaboutsApiClientBuilder,
     prisonerProfileDeliusApiClientBuilder,
     manageUsersApiClientBuilder,
+    bookAVideoLinkApiClientBuilder,
     complexityApiClientBuilder,
     calculateReleaseDatesApiClientBuilder,
     prisonRegisterApiClientBuilder,
@@ -94,6 +95,7 @@ export const services = () => {
     prisonApiClientBuilder,
     whereaboutsApiClientBuilder,
     manageUsersApiClientBuilder,
+    bookAVideoLinkApiClientBuilder,
   )
   const professionalContactsService = new ProfessionalContactsService(
     prisonApiClientBuilder,

--- a/server/validators/appointmentValidator.test.ts
+++ b/server/validators/appointmentValidator.test.ts
@@ -1,6 +1,7 @@
 import { addDays, addYears, subDays } from 'date-fns'
 import { AppointmentValidator } from './appointmentValidator'
 import { formatDate, formatDateISO } from '../utils/dateHelpers'
+import config from '../config'
 
 const todayStr = formatDate(formatDateISO(new Date()), 'short')
 const futureDate = formatDateISO(addDays(new Date(), 7))
@@ -81,6 +82,32 @@ describe('Validation middleware', () => {
       { text: 'Select the repeat period for this appointment', href: '#repeats' },
       { text: 'Enter the number of appointments using numbers only', href: '#times' },
       { text: 'Enter comments using 3,600 characters or less', href: '#comments' },
+    ])
+  })
+
+  it('should fail validation for missing vlb location when appointment type is VLB', async () => {
+    config.featureToggles.bookAVideoLinkEnabled = true
+
+    const appointmentForm = {
+      appointmentType: 'VLB',
+      date: formatDate(futureDate, 'short'),
+      startTimeHours: '10',
+      startTimeMinutes: '30',
+      endTimeHours: '11',
+      endTimeMinutes: '30',
+      recurring: 'yes',
+      repeats: 'DAILY',
+      times: '1',
+      comments: 'Comments',
+    }
+
+    const result = AppointmentValidator(appointmentForm)
+
+    expect(result).toEqual([
+      {
+        href: '#vlbLocation',
+        text: 'Select the location',
+      },
     ])
   })
 

--- a/server/validators/appointmentValidator.ts
+++ b/server/validators/appointmentValidator.ts
@@ -3,6 +3,7 @@ import { addYears, isAfter, isBefore, isPast, isWeekend, subDays } from 'date-fn
 import { Validator } from '../middleware/validationMiddleware'
 import HmppsError from '../interfaces/HmppsError'
 import { calculateEndDate, formatDate, formatDateISO, isRealDate, parseDate } from '../utils/dateHelpers'
+import config from '../config'
 
 export const AppointmentValidator: Validator = (body: Record<string, string>) => {
   const errors: HmppsError[] = []
@@ -19,14 +20,14 @@ export const AppointmentValidator: Validator = (body: Record<string, string>) =>
     })
   }
 
-  if (!body.location && body.appointmentType !== 'VLB') {
+  if (!body.location && (body.appointmentType !== 'VLB' || !config.featureToggles.bookAVideoLinkEnabled)) {
     errors.push({
       text: 'Select the location',
       href: '#location',
     })
   }
 
-  if (!body.vlbLocation && body.appointmentType === 'VLB') {
+  if (!body.vlbLocation && body.appointmentType === 'VLB' && config.featureToggles.bookAVideoLinkEnabled) {
     errors.push({
       text: 'Select the location',
       href: '#vlbLocation',

--- a/server/validators/appointmentValidator.ts
+++ b/server/validators/appointmentValidator.ts
@@ -19,10 +19,17 @@ export const AppointmentValidator: Validator = (body: Record<string, string>) =>
     })
   }
 
-  if (!body.location) {
+  if (!body.location && body.appointmentType !== 'VLB') {
     errors.push({
       text: 'Select the location',
       href: '#location',
+    })
+  }
+
+  if (!body.vlbLocation && body.appointmentType === 'VLB') {
+    errors.push({
+      text: 'Select the location',
+      href: '#vlbLocation',
     })
   }
 

--- a/server/validators/prePostAppointmentValidator.test.ts
+++ b/server/validators/prePostAppointmentValidator.test.ts
@@ -1,6 +1,11 @@
 import { PrePostAppointmentValidator } from './prePostAppointmentValidator'
+import config from '../config'
 
 describe('Validation middleware', () => {
+  beforeEach(() => {
+    config.featureToggles.bookAVideoLinkEnabled = false
+  })
+
   it('should pass validation with good data', async () => {
     const vlbForm = {
       preAppointment: 'no',
@@ -11,6 +16,20 @@ describe('Validation middleware', () => {
     const result = PrePostAppointmentValidator(vlbForm)
 
     expect(result).toEqual([])
+  })
+
+  it('should fail validation when hearing type is missing', async () => {
+    config.featureToggles.bookAVideoLinkEnabled = true
+
+    const vlbForm = {
+      preAppointment: 'no',
+      postAppointment: 'no',
+      court: 'CODE',
+    }
+
+    const result = PrePostAppointmentValidator(vlbForm)
+
+    expect(result).toEqual([{ text: 'Select the hearing type', href: '#hearingType' }])
   })
 
   it('should fail validation with no data', async () => {

--- a/server/validators/prePostAppointmentValidator.ts
+++ b/server/validators/prePostAppointmentValidator.ts
@@ -1,5 +1,6 @@
 import { Validator } from '../middleware/validationMiddleware'
 import HmppsError from '../interfaces/HmppsError'
+import config from '../config'
 
 // eslint-disable-next-line import/prefer-default-export
 export const PrePostAppointmentValidator: Validator = (body: Record<string, string>) => {
@@ -29,6 +30,10 @@ export const PrePostAppointmentValidator: Validator = (body: Record<string, stri
 
   if (!body.court) {
     errors.push({ text: 'Select which court the hearing is for', href: '#court' })
+  }
+
+  if (!body.hearingType && config.featureToggles.bookAVideoLinkEnabled) {
+    errors.push({ text: 'Select the hearing type', href: '#hearingType' })
   }
 
   if (body.court === 'other' && !body.otherCourt) {

--- a/server/views/pages/appointments/addAppointment.njk
+++ b/server/views/pages/appointments/addAppointment.njk
@@ -89,12 +89,31 @@
                     {{ govukSelect({
                         id: "location",
                         name: "location",
+                        formGroup: {
+                            classes: "js-appointment-locations-group"
+                        },
                         label: {
                             text: "Location"
                         },
+                        classes: 'govuk-!-width-one-half',
                         errorMessage: errors | findError('location'),
                         items: locations | addDefaultSelectedValue('Choose location') | setSelected(formValues.location)
                     }) }}
+                    {% if bookAVideoLinkEnabled %}
+                        {{ govukSelect({
+                            id: "vlbLocation",
+                            name: "vlbLocation",
+                            formGroup: {
+                                classes: "js-video-locations-group"
+                            },
+                            label: {
+                                text: "Location"
+                            },
+                            classes: 'js-video-location govuk-!-width-one-half',
+                            errorMessage: errors | findError('vlbLocation'),
+                            items: vlbLocations | addDefaultSelectedValue('Choose location') | setSelected(formValues.location)
+                        }) }}
+                    {% endif %}
                     {{ hmppsDatepicker({
                         id: "date",
                         name: "date",

--- a/server/views/pages/appointments/prePostAppointmentConfirmation.njk
+++ b/server/views/pages/appointments/prePostAppointmentConfirmation.njk
@@ -132,12 +132,20 @@
                     rows: [
                         {
                             key: {
-                            text: "Court location"
-                        },
+                                text: "Court location"
+                            },
                             value: {
-                            text: court
-                        }
-                        }
+                                text: court
+                            }
+                        },
+                        {
+                            key: {
+                                text: "Hearing type"
+                            },
+                            value: {
+                                text: hearingType
+                            }
+                        } if bookAVideoLinkEnabled
                     ]
                 }) }}
 

--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -194,7 +194,7 @@
                                     name: "hearingType",
                                     id: "hearingType",
                                     label: {
-                                        text: "Which is the hearing type?"
+                                        text: "What is the hearing type?"
                                     },
                                     items: hearingTypes | addDefaultSelectedValue('Choose hearing type') | setSelected(formValues.hearingType),
                                     errorMessage: errors | findError("hearingType")

--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -115,6 +115,7 @@
                     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                     <input type="hidden" id="date" name="date" value="{{ date }}"/>
                     <input type="hidden" id="bookingId" name="bookingId" value="{{ bookingId }}"/>
+                    <input type="hidden" id="prisonId" name="prisonId" value="{{ prisonId }}"/>
 
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
@@ -187,6 +188,18 @@
                                 items: courts | addDefaultSelectedValue('Choose court') | setSelected(formValues.court),
                                 errorMessage: errors | findError("court")
                             }) }}
+
+                            {% if bookAVideoLinkEnabled %}
+                                {{ govukSelect({
+                                    name: "hearingType",
+                                    id: "hearingType",
+                                    label: {
+                                        text: "Which is the hearing type?"
+                                    },
+                                    items: hearingTypes | addDefaultSelectedValue('Choose hearing type') | setSelected(formValues.hearingType),
+                                    errorMessage: errors | findError("hearingType")
+                                }) }}
+                            {% endif %}
                         </div>
                     </div>
 

--- a/tests/mocks/prisonApiClientMock.ts
+++ b/tests/mocks/prisonApiClientMock.ts
@@ -32,6 +32,7 @@ export const prisonApiClientMock = (): PrisonApiClient => ({
   getInmateDetail: jest.fn(),
   getInmatesAtLocation: jest.fn(),
   getLocation: jest.fn(),
+  getLocationByKey: jest.fn(),
   getLocationsForAppointments: jest.fn(),
   getMainOffence: jest.fn(),
   getMovements: jest.fn(),


### PR DESCRIPTION
Adds a feature toggle for Book a Video Link functionality.

When the toggle is `true`:
- Video link bookings are created via the Book A Video Link API rather than Whereabouts API.
- Locations offered for the appointment are video link enabled locations only
- "Other" is removed as an option in the list of courts
- An additional field is added to collect the court hearing type (reference data from BAVL API)
