### PR TITLE
MICN-164 Update case note subtype to use `active` prop instead of `activeFlag`

### DIFF
--- a/server/controllers/caseNotesController.ts
+++ b/server/controllers/caseNotesController.ts
@@ -337,7 +337,7 @@ export default class CaseNotesController {
    *
    * @param caseNoteTypes
    * @param type - preselected type to determine list of subTypes
-   * @param onlyActive - if true, filter out types/subtypes where activeFlag !== 'Y'
+   * @param onlyActive - if true, filter out types/subtypes where active is true
    */
   private mapCaseNoteTypes(caseNoteTypes: CaseNoteType[], type?: string, onlyActive = false) {
     const types = caseNoteTypes?.map(t => ({ value: t.code, text: t.description }))
@@ -355,7 +355,7 @@ export default class CaseNotesController {
       const selectedType = caseNoteTypes.find(t => t.code === type)
       if (selectedType) {
         subTypes = selectedType.subCodes
-          ?.filter(t => !onlyActive || t.activeFlag === 'Y')
+          ?.filter(t => !onlyActive || t.active)
           .map(subType => ({
             value: subType.code,
             text: subType.description,

--- a/server/data/interfaces/caseNotesApi/CaseNoteSubType.ts
+++ b/server/data/interfaces/caseNotesApi/CaseNoteSubType.ts
@@ -1,7 +1,7 @@
 export default interface CaseNoteSubType {
   code: string
   description: string
-  activeFlag: string
+  active: boolean
   sensitive: boolean
   restrictedUse: boolean
 }

--- a/server/data/localMockData/caseNoteTypesMock.ts
+++ b/server/data/localMockData/caseNoteTypesMock.ts
@@ -8,7 +8,7 @@ export const caseNoteTypesMock: CaseNoteType[] = [
       {
         code: 'ASSESSMENT',
         description: 'Assessment',
-        activeFlag: 'Y',
+        active: true,
         sensitive: false,
         restrictedUse: false,
       },
@@ -21,7 +21,7 @@ export const caseNoteTypesMock: CaseNoteType[] = [
       {
         code: 'OPEN_COMM',
         description: 'Open Case Note',
-        activeFlag: 'Y',
+        active: true,
         sensitive: true,
         restrictedUse: false,
       },
@@ -34,7 +34,7 @@ export const caseNoteTypesMock: CaseNoteType[] = [
       {
         code: 'IEP_ENC',
         description: 'Incentive Encouragement',
-        activeFlag: 'Y',
+        active: true,
         sensitive: false,
         restrictedUse: false,
       },
@@ -47,7 +47,7 @@ export const caseNoteTypesMock: CaseNoteType[] = [
       {
         code: 'IEP_WARN',
         description: 'Incentive warning',
-        activeFlag: 'Y',
+        active: true,
         sensitive: false,
         restrictedUse: false,
       },


### PR DESCRIPTION
MICN-164

`activeFlag` is now only used for Case Note Child type but not on Parent type.
and it is refactored into a boolean (`active`) in offender-case-notes service.

This PR updates case note api service to follow the updated API specs of offender-case-notes