### PR TITLE
Hearing type and court fonts to be bold during the create appointment journey

### DIFF
--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -183,7 +183,8 @@
                                 name: "court",
                                 id: "court",
                                 label: {
-                                    text: "Which court is the booking for?"
+                                    text: "Which court is the booking for?",
+                                    classes: 'govuk-!-font-weight-bold'
                                 },
                                 items: courts | addDefaultSelectedValue('Choose court') | setSelected(formValues.court),
                                 errorMessage: errors | findError("court")
@@ -194,7 +195,8 @@
                                     name: "hearingType",
                                     id: "hearingType",
                                     label: {
-                                        text: "What is the hearing type?"
+                                        text: "What is the hearing type?",
+                                        classes: 'govuk-!-font-weight-bold'
                                     },
                                     items: hearingTypes | addDefaultSelectedValue('Choose hearing type') | setSelected(formValues.hearingType),
                                     errorMessage: errors | findError("hearingType")


### PR DESCRIPTION
The court field and the hearing type field labels should be bolded to be consistent with the rest of the fields

![screencapture-localhost-3000-prisoner-G9137UL-prepost-appointments-2024-11-21-09_48_09](https://github.com/user-attachments/assets/c2ecefdb-911e-4708-8b28-cbfb52892a1c)
