### PR TITLE
MAP-1873 Swap to using locations-inside-prison-api for internal locations

### DIFF
--- a/assets/js/prePostAppointment.js
+++ b/assets/js/prePostAppointment.js
@@ -4,10 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const postAppointmentEventsContainer = document.getElementById('postAppointmentEventsContainer')
   const postAppointmentLocation = document.getElementById('postAppointmentLocation')
   const courtSelect = document.getElementById('court')
-  const otherCourtContainer = document.getElementById('otherCourtContainer')
 
   async function getPrePostEventsForLocation(input, container) {
-    const locationId = Number(input.value)
+    const locationId = input.value
     const date = document.getElementById('date').value
 
     const response =
@@ -18,15 +17,6 @@ document.addEventListener('DOMContentLoaded', () => {
       container.style.display = 'block'
     } else {
       container.style.display = 'none'
-    }
-  }
-
-  function showHideOtherCourt() {
-    const courtId = courtSelect.value
-    if (courtId === 'other') {
-      otherCourtContainer.style.display = 'block'
-    } else {
-      otherCourtContainer.style.display = 'none'
     }
   }
 
@@ -44,5 +34,4 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialise
   getPrePostEventsForLocation(preAppointmentLocation, preAppointmentEventsContainer)
   getPrePostEventsForLocation(postAppointmentLocation, postAppointmentEventsContainer)
-  showHideOtherCourt()
 })

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,6 +4,8 @@ import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import dpsPages from './integration_tests/mockApis/dpsPages'
 import prisonApi from './integration_tests/mockApis/prison'
+import nomisSyncPrisonerMappingApi from './integration_tests/mockApis/nomisSyncPrisonerMappingApi'
+import locationsInsidePrisonApi from './integration_tests/mockApis/locationsInsidePrisonApi'
 import prisonerSearchApi from './integration_tests/mockApis/prisonerSearch'
 import pomApi from './integration_tests/mockApis/pom'
 import keyWorkerApi from './integration_tests/mockApis/keyWorker'
@@ -50,6 +52,8 @@ export default defineConfig({
         ...tokenVerification,
         ...dpsPages,
         ...prisonApi,
+        ...locationsInsidePrisonApi,
+        ...nomisSyncPrisonerMappingApi,
         ...prisonerSearchApi,
         ...pomApi,
         ...keyWorkerApi,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,8 +4,6 @@ import auth from './integration_tests/mockApis/auth'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import dpsPages from './integration_tests/mockApis/dpsPages'
 import prisonApi from './integration_tests/mockApis/prison'
-import locationsInsidePrisonApi from './integration_tests/mockApis/locationsInsidePrisonApi'
-import nomisSyncPrisonerMappingApi from './integration_tests/mockApis/nomisSyncPrisonerMappingApi'
 import prisonerSearchApi from './integration_tests/mockApis/prisonerSearch'
 import pomApi from './integration_tests/mockApis/pom'
 import keyWorkerApi from './integration_tests/mockApis/keyWorker'
@@ -52,8 +50,6 @@ export default defineConfig({
         ...tokenVerification,
         ...dpsPages,
         ...prisonApi,
-        ...locationsInsidePrisonApi,
-        ...nomisSyncPrisonerMappingApi,
         ...prisonerSearchApi,
         ...pomApi,
         ...keyWorkerApi,

--- a/server/config.ts
+++ b/server/config.ts
@@ -95,7 +95,7 @@ export default {
       agent: new AgentConfig(Number(get('PRISON_API_TIMEOUT_DEADLINE', 20000))),
     },
     locationsInsidePrisonApi: {
-      url: get('LOCATIONS_INSIDE_PRISON_API_URL', 'http://localhost:8080', requiredInProduction),
+      url: get('LOCATIONS_INSIDE_PRISON_API_URL', 'http://localhost:8082', requiredInProduction),
       timeout: {
         response: Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_DEADLINE', 10000)),
@@ -103,7 +103,7 @@ export default {
       agent: new AgentConfig(Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_DEADLINE', 20000))),
     },
     nomisSyncPrisonerMappingApi: {
-      url: get('NOMIS_SYNC_PRISONER_MAPPING_API_URL', 'http://localhost:8080', requiredInProduction),
+      url: get('NOMIS_SYNC_PRISONER_MAPPING_API_URL', 'http://localhost:8082', requiredInProduction),
       timeout: {
         response: Number(get('NOMIS_SYNC_PRISONER_MAPPING_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('NOMIS_SYNC_PRISONER_MAPPING_API_TIMEOUT_DEADLINE', 10000)),

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -300,17 +300,14 @@ export default class AppointmentController {
       const { appointmentDefaults, appointmentForm, formValues } =
         appointmentFlash[0] as unknown as PrePostAppointmentDetails
 
-      let locationMap = {} as NomisSyncLocation
+      let location
       if (appointmentDefaults.locationId) {
-        locationMap = await this.locationDetailsService.getLocationMappingUsingNomisLocationId(
+        const { dpsLocationId } = await this.locationDetailsService.getLocationMappingUsingNomisLocationId(
           clientToken,
           appointmentDefaults.locationId,
         )
+        location = (locations as LocationsApiLocation[]).find(loc => loc.id === dpsLocationId)?.localName
       }
-
-      const location = (locations as LocationsApiLocation[]).find(
-        loc => loc.id === locationMap.dpsLocationId,
-      )?.localName
 
       const hearingTypes = objectToSelectOptions(
         await this.appointmentService.getCourtHearingTypes(clientToken),
@@ -394,11 +391,11 @@ export default class AppointmentController {
 
         const [preLocation, mainLocation, postLocation] = await Promise.all([
           preAppointmentLocation
-            ? this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +preAppointmentLocation)
+            ? this.locationDetailsService.getLocation(clientToken, preAppointmentLocation)
             : undefined,
-          this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +appointmentForm.location),
+          this.locationDetailsService.getLocation(clientToken, appointmentForm.location),
           postAppointmentLocation
-            ? this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +postAppointmentLocation)
+            ? this.locationDetailsService.getLocation(clientToken, postAppointmentLocation)
             : undefined,
         ])
 

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -27,6 +27,8 @@ import logger from '../../logger'
 import { PrisonUser } from '../interfaces/HmppsUser'
 import CreateVideoBookingRequest from '../data/interfaces/bookAVideoLinkApi/CreateVideoBookingRequest'
 import LocationDetailsService from '../services/locationDetailsService'
+import LocationsApiLocation from '../data/interfaces/locationsInsidePrisonApi/LocationsApiLocation'
+import NomisSyncLocation from '../data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncLocation'
 
 const PRE_POST_APPOINTMENT_DURATION_MINS = 15
 
@@ -82,7 +84,7 @@ export default class AppointmentController {
           cellLocation: formatLocation(cellLocation),
         },
         appointmentTypes: refDataToSelectOptions(appointmentTypes),
-        locations: objectToSelectOptions(locations, 'locationId', 'userDescription'),
+        locations: objectToSelectOptions(locations, 'id', 'localName'),
         repeatOptions,
         today: formatDate(now.toISOString(), 'short'),
         formValues,
@@ -132,11 +134,16 @@ export default class AppointmentController {
       if (!errors.length) {
         const startTime = formatDateTimeISO(set(parseDate(date), { hours: startTimeHours, minutes: startTimeMinutes }))
         const endTime = formatDateTimeISO(set(parseDate(date), { hours: endTimeHours, minutes: endTimeMinutes }))
-
+        // non-bvl locations ideintified via UUID/integer form id.  BVL locations identified via key
+        let nomisLocationId
+        if (location) {
+          const result = await this.locationDetailsService.getLocationMappingUsingDpsLocationId(clientToken, location)
+          nomisLocationId = result.nomisLocationId
+        }
         const appointmentsToCreate: AppointmentDefaults = {
           bookingId,
           appointmentType,
-          locationId: Number(location),
+          locationId: nomisLocationId || 0,
           startTime,
           endTime,
           comment: comments,
@@ -225,7 +232,7 @@ export default class AppointmentController {
       const appointmentType = appointmentTypes.find(
         type => type.code === appointmentDetails.appointmentType,
       )?.description
-      const location = locations.find(loc => loc.locationId === Number(appointmentDetails.location))?.userDescription
+      const location = locations.find(loc => loc.id === appointmentDetails.location)?.localName
       const repeats = repeatOptions.find(type => type.value === appointmentDetails.repeats)?.text
 
       const appointmentData = {
@@ -293,7 +300,17 @@ export default class AppointmentController {
       const { appointmentDefaults, appointmentForm, formValues } =
         appointmentFlash[0] as unknown as PrePostAppointmentDetails
 
-      const location = locations.find(loc => loc.locationId === +appointmentDefaults.locationId)?.userDescription
+      let locationMap = {} as NomisSyncLocation
+      if (appointmentDefaults.locationId) {
+        locationMap = await this.locationDetailsService.getLocationMappingUsingNomisLocationId(
+          clientToken,
+          appointmentDefaults.locationId,
+        )
+      }
+
+      const location = (locations as LocationsApiLocation[]).find(
+        loc => loc.id === locationMap.dpsLocationId,
+      )?.localName
 
       const hearingTypes = objectToSelectOptions(
         await this.appointmentService.getCourtHearingTypes(clientToken),
@@ -334,7 +351,7 @@ export default class AppointmentController {
         pageTitle: 'Video link booking details',
         ...appointmentData,
         courts: objectToSelectOptions(courts, 'code', 'description'),
-        locations: objectToSelectOptions(locations, 'locationId', 'userDescription'),
+        locations: objectToSelectOptions(locations, 'id', 'localName'),
         refererUrl: `/prisoner/${prisonerNumber}`,
         errors,
         hearingTypes,
@@ -377,11 +394,11 @@ export default class AppointmentController {
 
         const [preLocation, mainLocation, postLocation] = await Promise.all([
           preAppointmentLocation
-            ? this.locationDetailsService.getLocationByNomisLocationId(clientToken, +preAppointmentLocation)
+            ? this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +preAppointmentLocation)
             : undefined,
-          this.locationDetailsService.getLocationByNomisLocationId(clientToken, +appointmentForm.location),
+          this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +appointmentForm.location),
           postAppointmentLocation
-            ? this.locationDetailsService.getLocationByNomisLocationId(clientToken, +postAppointmentLocation)
+            ? this.locationDetailsService.getLocationMappingUsingNomisLocationId(clientToken, +postAppointmentLocation)
             : undefined,
         ])
 
@@ -490,13 +507,19 @@ export default class AppointmentController {
         this.appointmentService.getAgencyDetails(clientToken, prisonId),
       ])
 
-      const location = locations.find(loc => loc.locationId === +appointmentDefaults.locationId)?.userDescription
+      let apptDefaultsLocationMap = {} as NomisSyncLocation
+      if (appointmentDefaults.locationId) {
+        apptDefaultsLocationMap = await this.locationDetailsService.getLocationMappingUsingNomisLocationId(
+          clientToken,
+          appointmentDefaults.locationId,
+        )
+      }
 
-      const preLocation = locations.find(loc => loc.locationId === +formValues.preAppointmentLocation)?.userDescription
+      const location = locations.find(loc => loc.id === apptDefaultsLocationMap.dpsLocationId)?.localName
 
-      const postLocation = locations.find(
-        loc => loc.locationId === +formValues.postAppointmentLocation,
-      )?.userDescription
+      const preLocation = locations.find(loc => loc.id === formValues.preAppointmentLocation)?.localName
+
+      const postLocation = locations.find(loc => loc.id === formValues.postAppointmentLocation)?.localName
 
       const courtDescription = courts.find(court => court.code === formValues.court)?.description
 
@@ -640,13 +663,23 @@ export default class AppointmentController {
       const user = res.locals.user as PrisonUser
 
       const isoDate = dateToIsoDate(req.query.date as string)
-      const locationId = +req.query.locationId
+      // eslint-disable-next-line prefer-destructuring
+      const locationId = req.query.locationId
+
+      const { nomisLocationId } = await this.locationDetailsService.getLocationMappingUsingDpsLocationId(
+        clientToken,
+        locationId as string,
+      )
 
       const [location, events] = await Promise.all([
-        this.appointmentService.getLocation(clientToken, locationId),
-        this.appointmentService.getExistingEventsForLocation(clientToken, user.activeCaseLoadId, locationId, isoDate),
+        this.locationDetailsService.getLocation(clientToken, locationId as string),
+        this.appointmentService.getExistingEventsForLocation(
+          clientToken,
+          user.activeCaseLoadId,
+          nomisLocationId,
+          isoDate,
+        ),
       ])
-
       this.auditService
         .sendEvent({
           who: res.locals.user.username,
@@ -660,7 +693,7 @@ export default class AppointmentController {
       return res.render('components/scheduledEvents/scheduledEvents.njk', {
         events,
         date: formatDate(isoDate, 'long'),
-        header: `Schedule for ${location.userDescription}`,
+        header: `Schedule for ${location.localName}`,
         type: 'location',
       })
     }

--- a/server/data/interfaces/locationsInsidePrisonApi/LocationsApiLocation.ts
+++ b/server/data/interfaces/locationsInsidePrisonApi/LocationsApiLocation.ts
@@ -1,5 +1,5 @@
 export default interface LocationsApiLocation {
-  id: string
   key: string
+  id: string
   localName: string
 }

--- a/server/data/interfaces/locationsInsidePrisonApi/LocationsInsidePrisonApiClient.ts
+++ b/server/data/interfaces/locationsInsidePrisonApi/LocationsInsidePrisonApiClient.ts
@@ -2,4 +2,6 @@ import LocationsApiLocation from './LocationsApiLocation'
 
 export interface LocationsInsidePrisonApiClient {
   getLocation(locationId: string): Promise<LocationsApiLocation>
+  getLocationByKey(locationKey: string): Promise<LocationsApiLocation>
+  getLocationsForAppointments(prisonId: string): Promise<LocationsApiLocation[]>
 }

--- a/server/data/interfaces/locationsInsidePrisonApi/LocationsInsidePrisonApiClient.ts
+++ b/server/data/interfaces/locationsInsidePrisonApi/LocationsInsidePrisonApiClient.ts
@@ -2,6 +2,5 @@ import LocationsApiLocation from './LocationsApiLocation'
 
 export interface LocationsInsidePrisonApiClient {
   getLocation(locationId: string): Promise<LocationsApiLocation>
-  getLocationByKey(locationKey: string): Promise<LocationsApiLocation>
   getLocationsForAppointments(prisonId: string): Promise<LocationsApiLocation[]>
 }

--- a/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncLocation.ts
+++ b/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncLocation.ts
@@ -1,4 +1,7 @@
+// import Location from './Location'
+
 export default interface NomisSyncLocation {
   nomisLocationId: number
   dpsLocationId: string
+  key: string
 }

--- a/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncLocation.ts
+++ b/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncLocation.ts
@@ -3,5 +3,4 @@
 export default interface NomisSyncLocation {
   nomisLocationId: number
   dpsLocationId: string
-  key: string
 }

--- a/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncPrisonerMappingApiClient.ts
+++ b/server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncPrisonerMappingApiClient.ts
@@ -1,5 +1,6 @@
 import NomisSyncLocation from './NomisSyncLocation'
 
 export interface NomisSyncPrisonerMappingApiClient {
+  getMappingUsingDpsLocationId(id: string): Promise<NomisSyncLocation>
   getMappingUsingNomisLocationId(id: number): Promise<NomisSyncLocation>
 }

--- a/server/data/interfaces/prisonApi/prisonApiClient.ts
+++ b/server/data/interfaces/prisonApi/prisonApiClient.ts
@@ -38,7 +38,6 @@ import Movement from './Movement'
 import { MovementType } from '../../enums/movementType'
 import OffenderSentenceDetail from './OffenderSentenceDetail'
 import PrisonerSchedule, { PrisonerPrisonSchedule, TimeSlot } from './PrisonerSchedule'
-import Location from './Location'
 import Details from './Details'
 import AttributesForLocation from './AttributesForLocation'
 import HistoryForLocationItem from './HistoryForLocationItem'
@@ -170,8 +169,6 @@ export interface PrisonApiClient {
 
   getMovements(prisonerNumbers: string[], movementTypes: MovementType[], latestOnly?: boolean): Promise<Movement[]>
 
-  getLocationsForAppointments(agencyId: string): Promise<Location[]>
-
   getAppointmentTypes(): Promise<ReferenceCode[]>
 
   getSentenceData(offenderNumbers: string[]): Promise<OffenderSentenceDetail[]>
@@ -195,8 +192,6 @@ export interface PrisonApiClient {
   ): Promise<PrisonerSchedule[]>
 
   getExternalTransfers(offenderNumbers: string[], agencyId: string, date: string): Promise<PrisonerSchedule[]>
-
-  getLocation(locationId: number): Promise<Location>
 
   getActivitiesAtLocation(
     locationId: number,

--- a/server/data/interfaces/whereaboutsApi/Appointment.ts
+++ b/server/data/interfaces/whereaboutsApi/Appointment.ts
@@ -28,6 +28,7 @@ export interface AppointmentForm {
   times?: number
   comments?: string
   bookingId?: number
+  dpsLocationId?: string
 }
 
 export interface AppointmentDefaults {

--- a/server/data/localMockData/locationsMock.ts
+++ b/server/data/localMockData/locationsMock.ts
@@ -3,8 +3,8 @@ import { SelectOption } from '../../utils/utils'
 import LocationsApiLocation from '../interfaces/locationsInsidePrisonApi/LocationsApiLocation'
 
 export const locationsApiMock: LocationsApiLocation[] = [
-  { id: 'location-1', localName: 'Local name one' },
-  { id: 'location-2', localName: 'Local name two' },
+  { id: 'location-1', localName: 'Local name one', key: 'ABC' },
+  { id: 'location-2', localName: 'Local name two', key: 'ABC' },
 ]
 export const locationsMock: Location[] = [
   {
@@ -33,6 +33,10 @@ export const locationsApiSelectOptionsMock: SelectOption[] = [
   {
     text: 'Local name one',
     value: 'location-1',
+  },
+  {
+    text: 'Local name two',
+    value: 'location-2',
   },
 ]
 

--- a/server/data/localMockData/locationsMock.ts
+++ b/server/data/localMockData/locationsMock.ts
@@ -3,8 +3,8 @@ import { SelectOption } from '../../utils/utils'
 import LocationsApiLocation from '../interfaces/locationsInsidePrisonApi/LocationsApiLocation'
 
 export const locationsApiMock: LocationsApiLocation[] = [
-  { id: 'abc-123', key: 'MDI-WORK_IND-CES', localName: 'CES' },
-  { id: 'zyx-321', key: 'MDI-PROG_ACT-CHAP', localName: 'Chapel' },
+  { id: 'location-1', localName: 'Local name one' },
+  { id: 'location-2', localName: 'Local name two' },
 ]
 export const locationsMock: Location[] = [
   {
@@ -26,6 +26,13 @@ export const locationsMock: Location[] = [
     currentOccupancy: 0,
     locationPrefix: 'MDI-PROG_ACT-CHAP',
     userDescription: 'Chapel',
+  },
+]
+
+export const locationsApiSelectOptionsMock: SelectOption[] = [
+  {
+    text: 'Local name one',
+    value: 'location-1',
   },
 ]
 

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -46,13 +46,4 @@ describe('locationsInsidePrisonApiClient', () => {
       expect(output).toEqual(locationsApiMock[0])
     })
   })
-
-  describe('getLocationByKey', () => {
-    it('Should return data from the API', async () => {
-      const key = 'NMI-1-ABC'
-      mockSuccessfulApiCall(`/locations/key/${key}`, locationsApiMock[0])
-      const output = await locationsInsidePrisonApiClient.getLocationByKey(key)
-      expect(output).toEqual(locationsApiMock[0])
-    })
-  })
 })

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -26,11 +26,32 @@ describe('locationsInsidePrisonApiClient', () => {
       .reply(200, returnData)
   }
 
+  describe('getLocationsForAppointments', () => {
+    it('Should return data from the API', async () => {
+      const id = 'MDI'
+      mockSuccessfulApiCall(
+        `/locations/prison/${id}/non-residential-usage-type/APPOINTMENT?sortByLocalName=true&formatLocalName=true`,
+        locationsApiMock,
+      )
+      const output = await locationsInsidePrisonApiClient.getLocationsForAppointments(id)
+      expect(output).toEqual(locationsApiMock)
+    })
+  })
+
   describe('getLocation', () => {
     it('Should return data from the API', async () => {
       const id = 'MDI'
       mockSuccessfulApiCall(`/locations/${id}?formatLocalName=true`, locationsApiMock[0])
       const output = await locationsInsidePrisonApiClient.getLocation(id)
+      expect(output).toEqual(locationsApiMock[0])
+    })
+  })
+
+  describe('getLocationByKey', () => {
+    it('Should return data from the API', async () => {
+      const key = 'NMI-1-ABC'
+      mockSuccessfulApiCall(`/locations/key/${key}`, locationsApiMock[0])
+      const output = await locationsInsidePrisonApiClient.getLocationByKey(key)
       expect(output).toEqual(locationsApiMock[0])
     })
   })

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -15,4 +15,14 @@ export default class LocationsInsidePrisonApiRestClient implements LocationsInsi
   async getLocation(id: string): Promise<LocationsApiLocation> {
     return this.restClient.get<LocationsApiLocation>({ path: `/locations/${id}?formatLocalName=true` })
   }
+
+  async getLocationByKey(key: string): Promise<LocationsApiLocation> {
+    return this.restClient.get<LocationsApiLocation>({ path: `/locations/key/${key}` })
+  }
+
+  async getLocationsForAppointments(id: string): Promise<LocationsApiLocation[]> {
+    return this.restClient.get<LocationsApiLocation[]>({
+      path: `/locations/prison/${id}/non-residential-usage-type/APPOINTMENT?sortByLocalName=true&formatLocalName=true`,
+    })
+  }
 }

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -16,10 +16,6 @@ export default class LocationsInsidePrisonApiRestClient implements LocationsInsi
     return this.restClient.get<LocationsApiLocation>({ path: `/locations/${id}?formatLocalName=true` })
   }
 
-  async getLocationByKey(key: string): Promise<LocationsApiLocation> {
-    return this.restClient.get<LocationsApiLocation>({ path: `/locations/key/${key}` })
-  }
-
   async getLocationsForAppointments(id: string): Promise<LocationsApiLocation[]> {
     return this.restClient.get<LocationsApiLocation[]>({
       path: `/locations/prison/${id}/non-residential-usage-type/APPOINTMENT?sortByLocalName=true&formatLocalName=true`,

--- a/server/data/nomisSyncPrisonerMappingClient.test.ts
+++ b/server/data/nomisSyncPrisonerMappingClient.test.ts
@@ -37,4 +37,13 @@ describe('nomisSyncPrisonerMappingClient', () => {
       expect(output).toEqual(apiResponse)
     })
   })
+
+  describe('getMappingUsingDpsLocationId', () => {
+    it('Should return data from the API', async () => {
+      const dpsLocationId = 'abcdefg'
+      mockSuccessfulApiCall(`/api/locations/dps/${dpsLocationId}`, apiResponse)
+      const output = await nomisSyncPrisonerMappingClient.getMappingUsingDpsLocationId(dpsLocationId)
+      expect(output).toEqual(apiResponse)
+    })
+  })
 })

--- a/server/data/nomisSyncPrisonerMappingClient.ts
+++ b/server/data/nomisSyncPrisonerMappingClient.ts
@@ -17,4 +17,10 @@ export default class NomisSyncPrisonMappingRestClient implements NomisSyncPrison
       path: `/api/locations/nomis/${nomisLocationId}`,
     })
   }
+
+  async getMappingUsingDpsLocationId(dpsLocationId: string): Promise<NomisSyncLocation> {
+    return this.restClient.get({
+      path: `/api/locations/dps/${dpsLocationId}`,
+    })
+  }
 }

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -36,7 +36,6 @@ import { AccountCode } from './enums/accountCode'
 import { damageObligationContainerMock } from './localMockData/damageObligationsMock'
 import { MovementType } from './enums/movementType'
 import movementsMock from './localMockData/movementsData'
-import { locationsMock } from './localMockData/locationsMock'
 import { appointmentTypesMock } from './localMockData/appointmentTypesMock'
 import { offenderSentenceDetailsMock } from './localMockData/offenderSentenceDetailsMock'
 import { prisonerSchedulesMock } from './localMockData/prisonerSchedulesMock'
@@ -399,15 +398,6 @@ describe('prisonApiClient', () => {
     })
   })
 
-  describe('getLocationsForAppointments', () => {
-    it('Should return data from the API', async () => {
-      const agencyId = 'MDI'
-      mockSuccessfulPrisonApiCall(`/api/agencies/${agencyId}/locations?eventType=APP`, locationsMock)
-      const output = await prisonApiClient.getLocationsForAppointments(agencyId)
-      expect(output).toEqual(locationsMock)
-    })
-  })
-
   describe('getAppointmentTypes', () => {
     it('Should return data from the API', async () => {
       mockSuccessfulPrisonApiCall(`/api/reference-domains/scheduleReasons?eventType=APP`, appointmentTypesMock)
@@ -500,15 +490,6 @@ describe('prisonApiClient', () => {
       )
       const output = await prisonApiClient.getExternalTransfers(offenderNumbers, agencyId, date)
       expect(output).toEqual(prisonerSchedulesMock)
-    })
-  })
-
-  describe('getLocation', () => {
-    it('Should return data from the API', async () => {
-      const locationId = 27000
-      mockSuccessfulPrisonApiCall(`/api/locations/${locationId}`, locationsMock[0])
-      const output = await prisonApiClient.getLocation(locationId)
-      expect(output).toEqual(locationsMock[0])
     })
   })
 

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -47,7 +47,6 @@ import Movement from './interfaces/prisonApi/Movement'
 import { MovementType } from './enums/movementType'
 import OffenderSentenceDetail from './interfaces/prisonApi/OffenderSentenceDetail'
 import PrisonerSchedule, { PrisonerPrisonSchedule, TimeSlot } from './interfaces/prisonApi/PrisonerSchedule'
-import Location from './interfaces/prisonApi/Location'
 import Details from './interfaces/prisonApi/Details'
 import AttributesForLocation from './interfaces/prisonApi/AttributesForLocation'
 import HistoryForLocationItem from './interfaces/prisonApi/HistoryForLocationItem'
@@ -356,10 +355,6 @@ export default class PrisonApiRestClient implements PrisonApiClient {
     })) as Movement[]
   }
 
-  async getLocationsForAppointments(agencyId: string): Promise<Location[]> {
-    return this.restClient.get<Location[]>({ path: `/api/agencies/${agencyId}/locations?eventType=APP` })
-  }
-
   async getAppointmentTypes(): Promise<ReferenceCode[]> {
     return this.restClient.get<ReferenceCode[]>({ path: '/api/reference-domains/scheduleReasons?eventType=APP' })
   }
@@ -422,10 +417,6 @@ export default class PrisonApiRestClient implements PrisonApiClient {
       path: `/api/schedules/${agencyId}/externalTransfers?date=${date}`,
       data: offenderNumbers,
     })) as PrisonerSchedule[]
-  }
-
-  async getLocation(locationId: number): Promise<Location> {
-    return this.restClient.get<Location>({ path: `/api/locations/${locationId}` })
   }
 
   async getActivitiesAtLocation(

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -70,7 +70,7 @@ describe('Appointment Service', () => {
       const refData = await appointmentService.getAddAppointmentRefData('', 'MDI')
 
       expect(prisonApiClient.getAppointmentTypes).toHaveBeenCalled()
-      expect(locationDetailsService.getLocationsForAppointments).toHaveBeenCalled()
+      expect(locationDetailsService.getLocationsForAppointments).toHaveBeenCalledWith('', 'MDI')
       expect(refData).toEqual({ appointmentTypes: appointmentTypesMock, locations: locationsApiMock })
     })
   })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -106,6 +106,7 @@ export const services = () => {
   const csraService = new CsraService(prisonApiClientBuilder)
   const moneyService = new MoneyService(prisonApiClientBuilder)
   const appointmentService = new AppointmentService(
+    locationDetailsService,
     prisonApiClientBuilder,
     whereaboutsApiClientBuilder,
     bookAVideoLinkApiClientBuilder,

--- a/server/services/locationDetailsService.test.ts
+++ b/server/services/locationDetailsService.test.ts
@@ -51,7 +51,13 @@ describe('prisonerLocationDetailsService', () => {
   })
 
   describe('getLocation', () => {
-    const response = { id: 'abc', key: 'ABC', localName: 'Local name' }
+    const response = { id: 'abc', localName: 'Local name', key: 'ABC' }
+    it('returns data for single location', async () => {
+      locationsInsidePrisonApiClient.getLocation = jest.fn(async () => response)
+      await expect(service.getLocation('', 'abc')).resolves.toEqual(response)
+    })
+  })
+
   describe('getLocationMappingUsingDpsLocationId', () => {
     it('returns data mapping using Nomis locationId ', async () => {
       nomisSyncPrisonerMappingApiClient.getMappingUsingDpsLocationId = jest.fn(async () => mappingResponse)
@@ -59,34 +65,19 @@ describe('prisonerLocationDetailsService', () => {
     })
   })
 
-  describe('getLocation', () => {
-    const response = { id: 'abc', localName: 'Local name' }
-    it('returns data for single location', async () => {
-      locationsInsidePrisonApiClient.getLocation = jest.fn(async () => response)
-      await expect(service.getLocation('', 'abc')).resolves.toEqual(response)
-    })
-  })
+  describe('getMappingUsingNomisLocationId', () => {
+    const response = { id: 'abc', localName: 'Local name', key: 'ABC' }
 
-  describe('getLocationByNomisLocationId', () => {
-    const response = { id: 'abc', localName: 'Local name' }
     it('returns data for single location', async () => {
       nomisSyncPrisonerMappingApiClient.getMappingUsingNomisLocationId = jest.fn(async () => mappingResponse)
       locationsInsidePrisonApiClient.getLocation = jest.fn(async () => response)
-      await expect(service.getLocationMappingUsingNomisLocationId('', 123)).resolves.toEqual(response)
-      expect(locationsInsidePrisonApiClient.getLocation).lastCalledWith('abc')
-    })
-  })
-
-  describe('getLocationByKey', () => {
-    const response = { id: 'abc', localName: 'Local name' }
-    it('returns data for single location by key', async () => {
-      locationsInsidePrisonApiClient.getLocationByKey = jest.fn(async () => response)
-      await expect(service.getLocationByKey('', 'some-key')).resolves.toEqual(response)
+      await expect(service.getLocationMappingUsingNomisLocationId('', 123)).resolves.toEqual(mappingResponse)
+      expect(nomisSyncPrisonerMappingApiClient.getMappingUsingNomisLocationId).toHaveBeenCalledWith(123)
     })
   })
 
   describe('getLocationsForAppointments', () => {
-    const response = [{ id: 'abc', localName: 'Local name' }]
+    const response = [{ id: 'abc', localName: 'Local name', key: 'ABC' }]
     it('returns all location in prison having APPOINTMENT usage type ', async () => {
       locationsInsidePrisonApiClient.getLocationsForAppointments = jest.fn(async () => response)
       await expect(service.getLocationsForAppointments('', 'MDI')).resolves.toEqual(response)

--- a/server/services/locationDetailsService.test.ts
+++ b/server/services/locationDetailsService.test.ts
@@ -52,6 +52,15 @@ describe('prisonerLocationDetailsService', () => {
 
   describe('getLocation', () => {
     const response = { id: 'abc', key: 'ABC', localName: 'Local name' }
+  describe('getLocationMappingUsingDpsLocationId', () => {
+    it('returns data mapping using Nomis locationId ', async () => {
+      nomisSyncPrisonerMappingApiClient.getMappingUsingDpsLocationId = jest.fn(async () => mappingResponse)
+      await expect(service.getLocationMappingUsingDpsLocationId('', 'abc')).resolves.toEqual(mappingResponse)
+    })
+  })
+
+  describe('getLocation', () => {
+    const response = { id: 'abc', localName: 'Local name' }
     it('returns data for single location', async () => {
       locationsInsidePrisonApiClient.getLocation = jest.fn(async () => response)
       await expect(service.getLocation('', 'abc')).resolves.toEqual(response)
@@ -59,15 +68,30 @@ describe('prisonerLocationDetailsService', () => {
   })
 
   describe('getLocationByNomisLocationId', () => {
-    const response = { id: 'abc', key: 'ABC', localName: 'Local name' }
+    const response = { id: 'abc', localName: 'Local name' }
     it('returns data for single location', async () => {
       nomisSyncPrisonerMappingApiClient.getMappingUsingNomisLocationId = jest.fn(async () => mappingResponse)
       locationsInsidePrisonApiClient.getLocation = jest.fn(async () => response)
-      await expect(service.getLocationByNomisLocationId('', 123)).resolves.toEqual(response)
+      await expect(service.getLocationMappingUsingNomisLocationId('', 123)).resolves.toEqual(response)
       expect(locationsInsidePrisonApiClient.getLocation).lastCalledWith('abc')
     })
   })
 
+  describe('getLocationByKey', () => {
+    const response = { id: 'abc', localName: 'Local name' }
+    it('returns data for single location by key', async () => {
+      locationsInsidePrisonApiClient.getLocationByKey = jest.fn(async () => response)
+      await expect(service.getLocationByKey('', 'some-key')).resolves.toEqual(response)
+    })
+  })
+
+  describe('getLocationsForAppointments', () => {
+    const response = [{ id: 'abc', localName: 'Local name' }]
+    it('returns all location in prison having APPOINTMENT usage type ', async () => {
+      locationsInsidePrisonApiClient.getLocationsForAppointments = jest.fn(async () => response)
+      await expect(service.getLocationsForAppointments('', 'MDI')).resolves.toEqual(response)
+    })
+  })
   describe('getInmatesAtLocation', () => {
     it('returns data about inmates sharing a location', async () => {
       prisonApiClient.getInmatesAtLocation = jest.fn(async () => [mockInmateAtLocation])

--- a/server/services/locationDetailsService.ts
+++ b/server/services/locationDetailsService.ts
@@ -29,8 +29,10 @@ export default class LocationDetailsService {
     return this.locationsInsidePrisonApiClientBuilder(clientToken).getLocation(locationId)
   }
 
-  public async getLocationByKey(clientToken: string, locationKey: string): Promise<LocationsApiLocation> {
-    return this.locationsInsidePrisonApiClientBuilder(clientToken).getLocationByKey(locationKey)
+  getLocationByNomisLocationId = (clientToken: string, locationId: number): Promise<LocationsApiLocation> => {
+    return this.getLocationMappingUsingNomisLocationId(clientToken, locationId).then(map =>
+      this.getLocation(clientToken, map.dpsLocationId),
+    )
   }
 
   public async getLocationsForAppointments(clientToken: string, prisonId: string): Promise<LocationsApiLocation[]> {

--- a/server/services/locationDetailsService.ts
+++ b/server/services/locationDetailsService.ts
@@ -21,14 +21,20 @@ export default class LocationDetailsService {
     return this.nomisSyncPrisonMappingClientBuilder(clientToken).getMappingUsingNomisLocationId(locationId)
   }
 
+  getLocationMappingUsingDpsLocationId = (clientToken: string, locationId: string): Promise<NomisSyncLocation> => {
+    return this.nomisSyncPrisonMappingClientBuilder(clientToken).getMappingUsingDpsLocationId(locationId)
+  }
+
   public async getLocation(clientToken: string, locationId: string): Promise<LocationsApiLocation> {
     return this.locationsInsidePrisonApiClientBuilder(clientToken).getLocation(locationId)
   }
 
-  getLocationByNomisLocationId = (clientToken: string, locationId: number): Promise<LocationsApiLocation> => {
-    return this.getLocationMappingUsingNomisLocationId(clientToken, locationId).then(map =>
-      this.getLocation(clientToken, map.dpsLocationId),
-    )
+  public async getLocationByKey(clientToken: string, locationKey: string): Promise<LocationsApiLocation> {
+    return this.locationsInsidePrisonApiClientBuilder(clientToken).getLocationByKey(locationKey)
+  }
+
+  public async getLocationsForAppointments(clientToken: string, prisonId: string): Promise<LocationsApiLocation[]> {
+    return this.locationsInsidePrisonApiClientBuilder(clientToken).getLocationsForAppointments(prisonId)
   }
 
   getInmatesAtLocation = (clientToken: string, livingUnitId: number): Promise<OffenderBooking[]> => {

--- a/tests/mocks/locationsInsidePrisonApiClientMock.ts
+++ b/tests/mocks/locationsInsidePrisonApiClientMock.ts
@@ -2,4 +2,6 @@ import { LocationsInsidePrisonApiClient } from '../../server/data/interfaces/loc
 
 export const locationsInsidePrisonApiClientMock = (): LocationsInsidePrisonApiClient => ({
   getLocation: jest.fn(),
+  getLocationByKey: jest.fn(),
+  getLocationsForAppointments: jest.fn(),
 })

--- a/tests/mocks/locationsInsidePrisonApiClientMock.ts
+++ b/tests/mocks/locationsInsidePrisonApiClientMock.ts
@@ -2,6 +2,5 @@ import { LocationsInsidePrisonApiClient } from '../../server/data/interfaces/loc
 
 export const locationsInsidePrisonApiClientMock = (): LocationsInsidePrisonApiClient => ({
   getLocation: jest.fn(),
-  getLocationByKey: jest.fn(),
   getLocationsForAppointments: jest.fn(),
 })

--- a/tests/mocks/nomisSyncPrisonerMappingApiClientMock.ts
+++ b/tests/mocks/nomisSyncPrisonerMappingApiClientMock.ts
@@ -1,5 +1,6 @@
 import { NomisSyncPrisonerMappingApiClient } from '../../server/data/interfaces/nomisSyncPrisonerMappingApi/NomisSyncPrisonerMappingApiClient'
 
 export const nomisSyncPrisonerMappingApiClientMock = (): NomisSyncPrisonerMappingApiClient => ({
+  getMappingUsingDpsLocationId: jest.fn(),
   getMappingUsingNomisLocationId: jest.fn(),
 })

--- a/tests/mocks/prisonApiClientMock.ts
+++ b/tests/mocks/prisonApiClientMock.ts
@@ -28,8 +28,6 @@ export const prisonApiClientMock = (): PrisonApiClient => ({
   getImage: jest.fn(),
   getInmateDetail: jest.fn(),
   getInmatesAtLocation: jest.fn(),
-  getLocation: jest.fn(),
-  getLocationsForAppointments: jest.fn(),
   getMainOffence: jest.fn(),
   getMovements: jest.fn(),
   getOffenceHistory: jest.fn(),

--- a/tests/mocks/prisonerLocationDetailsServiceMock.ts
+++ b/tests/mocks/prisonerLocationDetailsServiceMock.ts
@@ -8,7 +8,7 @@ export const locationDetailsServiceMock = (): Interface<LocationDetailsService> 
   getLocationDetailsGroupedByPeriodAtAgency: jest.fn(),
   getLocationMappingUsingNomisLocationId: jest.fn(),
   getLocation: jest.fn(),
+  getLocationByNomisLocationId: jest.fn(),
   getLocationMappingUsingDpsLocationId: jest.fn(),
-  getLocationByKey: jest.fn(),
   getLocationsForAppointments: jest.fn(),
 })

--- a/tests/mocks/prisonerLocationDetailsServiceMock.ts
+++ b/tests/mocks/prisonerLocationDetailsServiceMock.ts
@@ -8,5 +8,7 @@ export const locationDetailsServiceMock = (): Interface<LocationDetailsService> 
   getLocationDetailsGroupedByPeriodAtAgency: jest.fn(),
   getLocationMappingUsingNomisLocationId: jest.fn(),
   getLocation: jest.fn(),
-  getLocationByNomisLocationId: jest.fn(),
+  getLocationMappingUsingDpsLocationId: jest.fn(),
+  getLocationByKey: jest.fn(),
+  getLocationsForAppointments: jest.fn(),
 })


### PR DESCRIPTION
The objective behind this code change is to replace calls that get location(s) from prison-api with calls to locations-inside-prison-api. 

The specific api endpoints changed are called by these functions in locationsInsidePrisonApiClient.ts. They have the same name as previously in prisonApiClient.
- getLocation
- getLocationsForAppointments

The key pages affected are 
- prisoner/{prisonNumber}/add-appointment
- prisoner/{prisonNumber}/appointment-confirmation

The nomis-sync-prisoner-mapping-api is used to get the corresponding location id between the prison-api and locations-inside-prison-api

Where used, dpsLocationId refers to the new uuid type id returned in the new locationsInsidePrisonApi object and nomisLocationId refers to the (current) integer type id  returned in the prisonApi object

Data passed to the backend for persisting will still use the Nomis version of location id. The nomis-sync-prisoner-mapping-api is used to find the nomisLocationId from the dpsLocationId and vice-versa.

[locations api swagger](https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs)

[sync api swagger](https://nomis-sync-prisoner-mapping-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html)