### PR TITLE
BAVL-623: Suppress movement slip comments for VLB and VLPM appointments only.

### DIFF
--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const appointmentLocationSelect = document.getElementById('location')
   const appointmentTypeSelect = document.getElementById('appointmentType')
   const recurringRadios = document.querySelector('.js-recurring-radios')
+  const optionalVideoLabel = document.getElementById('optional-video-label')
   const appointmentRepeatsSelect = document.getElementById('repeats')
   const appointmentRepeatsTimesInput = document.getElementById('times')
   const lastAppointmentDate = document.getElementById('last-appointment-date')
@@ -66,13 +67,28 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function showHideVideoLabel() {
+    const appointmentType = appointmentTypeSelect.value
+
+    if (appointmentType === 'VLB' || appointmentType === 'VLPM') {
+      optionalVideoLabel.style.display = 'block'
+    } else {
+      optionalVideoLabel.style.display = 'none'
+    }
+  }
+
   appointmentTypeSelect.addEventListener('change', () => {
     showHideRecurring()
+  })
+
+  appointmentTypeSelect.addEventListener('change', () => {
+    showHideVideoLabel()
   })
 
   appointmentLocationSelect.addEventListener('change', () => {
     getEventsForLocation()
   })
+
   appointmentDateInput.addEventListener('change', () => {
     getEventsForLocation()
   })
@@ -84,9 +100,11 @@ document.addEventListener('DOMContentLoaded', () => {
   appointmentRepeatsSelect.addEventListener('change', () => {
     getAppointmentEndDate()
   })
+
   appointmentDateInput.addEventListener('change', () => {
     getAppointmentEndDate()
   })
+
   appointmentRepeatsTimesInput.addEventListener('keyup', () => {
     getAppointmentEndDate()
   })
@@ -96,4 +114,5 @@ document.addEventListener('DOMContentLoaded', () => {
   getEventsForLocation()
   getAppointmentEndDate()
   showHideRecurring()
+  showHideVideoLabel()
 })

--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -79,9 +79,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   appointmentTypeSelect.addEventListener('change', () => {
     showHideRecurring()
-  })
-
-  appointmentTypeSelect.addEventListener('change', () => {
     showHideVideoLabel()
   })
 

--- a/server/controllers/appointmentController.ts
+++ b/server/controllers/appointmentController.ts
@@ -307,6 +307,7 @@ export default class AppointmentController {
         heading,
         prisonerName,
         prisonerNumber,
+        appointmentTypeCode: appointmentDetails.appointmentType,
         appointmentType,
         location,
         date: formatDate(dateToIsoDate(appointmentDetails.date), 'long'),
@@ -676,6 +677,8 @@ export default class AppointmentController {
 
       const appointmentData = {
         bookingType: formValues.bookingType,
+        appointmentTypeCode: 'VLB',
+        appointmentType: 'Video Link - Court Hearing',
         prisonerName,
         prisonerNumber,
         prisonName: prison.description,
@@ -713,7 +716,6 @@ export default class AppointmentController {
       // Save appointment details to session for movement slips to pick up if needed
       req.session.movementSlipData = {
         ...appointmentData,
-        appointmentType: 'Video Link Booking',
         comment: appointmentData.comments,
         prisonerNumber,
         cellLocation: formatLocation(cellLocation),

--- a/server/controllers/appointmentsController.test.ts
+++ b/server/controllers/appointmentsController.test.ts
@@ -393,6 +393,7 @@ describe('Appointments Controller', () => {
       prisonerName: 'John Saunders',
       prisonerNumber,
       appointmentType: 'Activities',
+      appointmentTypeCode: 'ACTI',
       location: 'Local name one',
       date: formatDate(dateToIsoDate(formBody.date), 'long'),
       startTime: `${formBody.startTimeHours}:${formBody.startTimeMinutes}`,
@@ -669,6 +670,8 @@ describe('Appointments Controller', () => {
       prisonerName: 'John Saunders',
       prisonerNumber,
       prisonName: 'Moorland (HMP & YOI)',
+      appointmentType: 'Video Link - Court Hearing',
+      appointmentTypeCode: 'VLB',
       location: locationsApiMock[0].localName,
       date: formatDate(dateToIsoDate(formBody.date), 'long'),
       startTime: `${formBody.startTimeHours}:${formBody.startTimeMinutes}`,
@@ -733,6 +736,8 @@ describe('Appointments Controller', () => {
       return []
     }
     const appointmentData = {
+      appointmentType: 'Video Link - Court Hearing',
+      appointmentTypeCode: 'VLB',
       prisonerName: 'John Saunders',
       prisonerNumber,
       prisonName: 'Moorland (HMP & YOI)',

--- a/server/views/pages/appointments/addAppointment.njk
+++ b/server/views/pages/appointments/addAppointment.njk
@@ -193,6 +193,10 @@
                         ]
                     }) }}
 
+                    <div id="optional-video-label" class="govuk-label">
+                      <p>For confidentiality reasons, comments for Video Link - Court Hearing and Video Link - Probation Meeting appointments will not appear on movement slips.</p>
+                    </div>
+
                     {{ govukTextarea({
                         name: "comments",
                         id: "comments",

--- a/server/views/pages/appointments/movementSlips.njk
+++ b/server/views/pages/appointments/movementSlips.njk
@@ -30,7 +30,13 @@
             {{ labelAndValue('Date and time', date +' ' + startTime + ' to ' + endTime) }}
             {{ labelAndValue('Moving to', location) }}
             {{ labelAndValue('Reason', appointmentType) }}
-            {{ labelAndValue('Comments', comment, true) }}
+
+            {# Suppress comments for VLB and VLPM appointments - can contain personal contact data #}
+            {% if (appointmentTypeCode == 'VLB') or (appointmentTypeCode == 'VLPM') %}
+                {{ labelAndValue('Comments', ' ', true) }}
+            {% else %}
+                {{ labelAndValue('Comments', comment, true) }}
+            {% endif %}
         </div>
 
         <div class="movement-slip__section">


### PR DESCRIPTION
This PR:

* Suppresses comments on movement slips for VLB (video court) and VLPM (video probation meetings), because they often contain contact details and personal info for attendees.
* It also show an optional label text on comment entry for these two appointment types to inform the user.

![image](https://github.com/user-attachments/assets/3718ed77-4322-4598-b950-7c439f5b8915)

![image](https://github.com/user-attachments/assets/aee09543-0d7f-45fe-a548-8edd1efe6134)

