### PR TITLE
BAVL-840 this change removes the master VLPM appointment types feature toggle. The code sitting behind this is now safe to use, the old code can go.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,7 +24,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     CONTENTFUL_ENVIRONMENT: "master"
-    BVLS_MASTERED_VLPM_FEATURE_TOGGLE_ENABLED: "true"
 
     # UI Service urls
     ADJUDICATIONS_UI_URL: "https://manage-adjudications-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,7 +23,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     CONTENTFUL_ENVIRONMENT: "master"
-    BVLS_MASTERED_VLPM_FEATURE_TOGGLE_ENABLED: "true"
 
     # UI Service urls
     ADJUDICATIONS_UI_URL: "https://manage-adjudications-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,7 +26,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     CONTENTFUL_ENVIRONMENT: "master"
-    BVLS_MASTERED_VLPM_FEATURE_TOGGLE_ENABLED: "true"
 
     # UI Service urls
     ASSESS_FOR_EARLY_RELEASE_UI_URL: "https://assess-for-early-release.hmpps.service.justice.gov.uk"

--- a/server/config.ts
+++ b/server/config.ts
@@ -369,7 +369,6 @@ export default {
     dietAndAllergyEnabledPrisonsFrom: get('DIET_AND_ALLERGY_ENABLED_FROM', '2099-01-01T00:00:00'),
 
     militaryHistoryEnabledFrom: get('MILITARY_HISTORY_ENABLED_FROM', '2099-01-01T00:00:00'),
-    bvlsMasteredVlpmFeatureToggleEnabled: toBoolean(get('BVLS_MASTERED_VLPM_FEATURE_TOGGLE_ENABLED', 'false')),
     externalContactsEnabledPrisons: get('EXTERNAL_CONTACTS_ENABLED_PRISONS', []),
     newOverviewPageLayoutEnabled: toBoolean(get('NEW_OVERVIEW_PAGE_LAYOUT_ENABLED', 'false')),
     manageAllocationsEnabled: toBoolean(get('MANAGE_ALLOCATIONS_ENABLED', 'false')),

--- a/server/services/appointmentService.test.ts
+++ b/server/services/appointmentService.test.ts
@@ -16,7 +16,6 @@ import CreateVideoBookingRequest, {
   VideoBookingSearchRequest,
 } from '../data/interfaces/bookAVideoLinkApi/VideoLinkBooking'
 import LocationDetailsService from './locationDetailsService'
-import config from '../config'
 
 jest.mock('../data/prisonApiClient')
 jest.mock('../data/whereaboutsClient')
@@ -73,11 +72,7 @@ describe('Appointment Service', () => {
     jest.restoreAllMocks()
   })
 
-  describe.each([[true], [false]])('getAddAppointmentRefData - bvlsMasteredVlpmFeatureToggleEnabled %s', toggle => {
-    beforeEach(() => {
-      config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled = toggle
-    })
-
+  describe('getAddAppointmentRefData - bvls', () => {
     it('should call API to get ref data', async () => {
       locationDetailsService.getLocationsForAppointments = jest.fn().mockResolvedValue(locationsApiMock)
       const refData = await appointmentService.getAddAppointmentRefData('', 'MDI')
@@ -85,33 +80,18 @@ describe('Appointment Service', () => {
       expect(prisonApiClient.getAppointmentTypes).toHaveBeenCalled()
       expect(locationDetailsService.getLocationsForAppointments).toHaveBeenCalledWith('', 'MDI')
 
-      if (toggle) {
-        expect(bookAVideoLinkApiClient.getProbationTeams).toHaveBeenCalled()
-        expect(bookAVideoLinkApiClient.getProbationMeetingTypes).toHaveBeenCalled()
-        expect(refData).toEqual({
-          appointmentTypes: appointmentTypesMock,
-          locations: locationsApiMock,
-          probationTeams: probationTeamsMock,
-          meetingTypes: probationMeetingTypes,
-        })
-      } else {
-        expect(bookAVideoLinkApiClient.getProbationTeams).not.toHaveBeenCalled()
-        expect(bookAVideoLinkApiClient.getProbationMeetingTypes).not.toHaveBeenCalled()
-        expect(refData).toEqual({
-          appointmentTypes: appointmentTypesMock,
-          locations: locationsApiMock,
-          probationTeams: [],
-          meetingTypes: [],
-        })
-      }
+      expect(bookAVideoLinkApiClient.getProbationTeams).toHaveBeenCalled()
+      expect(bookAVideoLinkApiClient.getProbationMeetingTypes).toHaveBeenCalled()
+      expect(refData).toEqual({
+        appointmentTypes: appointmentTypesMock,
+        locations: locationsApiMock,
+        probationTeams: probationTeamsMock,
+        meetingTypes: probationMeetingTypes,
+      })
     })
   })
 
-  describe.each([[true], [false]])('getPrePostAppointmentRefData - bvlsMasteredVlpmFeatureToggleEnabled %s', toggle => {
-    beforeEach(() => {
-      config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled = toggle
-    })
-
+  describe('getPrePostAppointmentRefData - bvls', () => {
     it('should call API to get ref data', async () => {
       locationDetailsService.getLocationsForAppointments = jest.fn().mockResolvedValue(locationsApiMock)
       const refData = await appointmentService.getPrePostAppointmentRefData('', 'MDI')
@@ -120,27 +100,15 @@ describe('Appointment Service', () => {
       expect(bookAVideoLinkApiClient.getCourtHearingTypes).toHaveBeenCalled()
       expect(locationDetailsService.getLocationsForAppointments).toHaveBeenCalled()
 
-      if (toggle) {
-        expect(bookAVideoLinkApiClient.getProbationTeams).not.toHaveBeenCalled()
-        expect(bookAVideoLinkApiClient.getProbationMeetingTypes).not.toHaveBeenCalled()
-        expect(refData).toEqual({
-          courts: courtLocationsMock,
-          hearingTypes: courtHearingTypes,
-          probationTeams: [],
-          meetingTypes: [],
-          locations: locationsApiMock,
-        })
-      } else {
-        expect(bookAVideoLinkApiClient.getProbationTeams).toHaveBeenCalled()
-        expect(bookAVideoLinkApiClient.getProbationMeetingTypes).toHaveBeenCalled()
-        expect(refData).toEqual({
-          courts: courtLocationsMock,
-          hearingTypes: courtHearingTypes,
-          probationTeams: probationTeamsMock,
-          meetingTypes: probationMeetingTypes,
-          locations: locationsApiMock,
-        })
-      }
+      expect(bookAVideoLinkApiClient.getProbationTeams).not.toHaveBeenCalled()
+      expect(bookAVideoLinkApiClient.getProbationMeetingTypes).not.toHaveBeenCalled()
+      expect(refData).toEqual({
+        courts: courtLocationsMock,
+        hearingTypes: courtHearingTypes,
+        probationTeams: [],
+        meetingTypes: [],
+        locations: locationsApiMock,
+      })
     })
   })
 

--- a/server/services/appointmentService.ts
+++ b/server/services/appointmentService.ts
@@ -16,7 +16,6 @@ import CreateVideoBookingRequest, {
 import Court, { ProbationTeam } from '../data/interfaces/bookAVideoLinkApi/Court'
 import LocationDetailsService from './locationDetailsService'
 import LocationsApiLocation from '../data/interfaces/locationsInsidePrisonApi/LocationsApiLocation'
-import { bvlsMasteredVlpmFeatureToggleEnabled } from '../utils/featureToggles'
 
 export interface AddAppointmentRefData {
   appointmentTypes: ReferenceCode[]
@@ -91,10 +90,8 @@ export default class AppointmentService {
     const [appointmentTypes, locations, probationTeams, meetingTypes] = await Promise.all([
       this.prisonApiClientBuilder(token).getAppointmentTypes(),
       this.locationDetailsService.getLocationsForAppointments(token, prisonId),
-      bvlsMasteredVlpmFeatureToggleEnabled() ? this.bookAVideoLinkApiClientBuilder(token).getProbationTeams() : [],
-      bvlsMasteredVlpmFeatureToggleEnabled()
-        ? this.bookAVideoLinkApiClientBuilder(token).getProbationMeetingTypes()
-        : [],
+      this.bookAVideoLinkApiClientBuilder(token).getProbationTeams(),
+      this.bookAVideoLinkApiClientBuilder(token).getProbationMeetingTypes(),
     ])
 
     return {
@@ -114,11 +111,9 @@ export default class AppointmentService {
   public async getPrePostAppointmentRefData(token: string, prisonId: string): Promise<PrePostAppointmentRefData> {
     const [courts, probationTeams, hearingTypes, meetingTypes, locations] = await Promise.all([
       this.bookAVideoLinkApiClientBuilder(token).getCourts(),
-      !bvlsMasteredVlpmFeatureToggleEnabled() ? this.bookAVideoLinkApiClientBuilder(token).getProbationTeams() : [],
+      [],
       this.bookAVideoLinkApiClientBuilder(token).getCourtHearingTypes(),
-      !bvlsMasteredVlpmFeatureToggleEnabled()
-        ? this.bookAVideoLinkApiClientBuilder(token).getProbationMeetingTypes()
-        : [],
+      [],
       this.locationDetailsService.getLocationsForAppointments(token, prisonId),
     ])
 

--- a/server/utils/featureToggles.ts
+++ b/server/utils/featureToggles.ts
@@ -17,5 +17,3 @@ export const newOverviewPageLayoutEnabled = () => config.featureToggles.newOverv
 
 export const externalContactsEnabled = (activeCaseLoadId: string) =>
   newOverviewPageLayoutEnabled() && config.featureToggles.externalContactsEnabledPrisons.includes(activeCaseLoadId)
-
-export const bvlsMasteredVlpmFeatureToggleEnabled = () => config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -61,12 +61,7 @@ import groupDistinguishingMarks, {
 import distinguishingMarkBodyPartsToDisplay from '../views/dataUtils/distinguishingMarkBodyPartsToDisplay'
 import getDistinguishingFeatureDetailsFormData from '../views/dataUtils/getDistinguishingMarkDetailsFormConfig'
 import currentCsipDetailToMiniCardContent from '../views/dataUtils/currentCsipDetailToMiniCardContent'
-import {
-  bvlsMasteredVlpmFeatureToggleEnabled,
-  externalContactsEnabled,
-  militaryHistoryEnabled,
-  newOverviewPageLayoutEnabled,
-} from './featureToggles'
+import { externalContactsEnabled, militaryHistoryEnabled, newOverviewPageLayoutEnabled } from './featureToggles'
 import nonAssociationSummaryToMiniSummary from '../views/dataUtils/nonAssociationSummaryToMiniSummary'
 import categorySummaryToMiniSummaryOldLayout from '../views/dataUtils/categorySummaryToMiniSummaryOldLayout'
 import incentiveSummaryToMiniSummaryOldLayout from '../views/dataUtils/incentiveSummaryToMiniSummaryOldLayout'
@@ -124,7 +119,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('militaryHistoryEnabled', militaryHistoryEnabled)
   njkEnv.addGlobal('externalContactsEnabled', externalContactsEnabled)
   njkEnv.addGlobal('useNewOverviewPageLayout', newOverviewPageLayoutEnabled)
-  njkEnv.addGlobal('bvlsMasteredVlpmFeatureToggleEnabled', bvlsMasteredVlpmFeatureToggleEnabled)
   njkEnv.addGlobal('currentTimeMillis', () => Date.now().toString())
 
   njkEnv.addFilter('initialiseName', initialiseName)

--- a/server/validators/appointmentValidator.test.ts
+++ b/server/validators/appointmentValidator.test.ts
@@ -1,24 +1,19 @@
 import { addDays, addYears, subDays } from 'date-fns'
 import { AppointmentValidator } from './appointmentValidator'
 import { formatDate, formatDateISO } from '../utils/dateHelpers'
-import config from '../config'
 
 const todayStr = formatDate(formatDateISO(new Date()), 'short')
 const futureDate = formatDateISO(addDays(new Date(), 7))
 const futureDateYear = formatDateISO(addYears(new Date(), 1))
 
-describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s', toggle => {
-  beforeEach(() => {
-    config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled = toggle
-  })
-
+describe('Validation middleware - VLPM appointment', () => {
   it('should pass validation with good data', async () => {
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerDetailsNotKnown: toggle ? 'true' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerDetailsNotKnown: 'true',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(futureDate, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -79,35 +74,31 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
 
     const result = AppointmentValidator(appointmentForm)
 
-    if (toggle) {
-      expect(result).toEqual([
-        {
-          href: '#probationTeam',
-          text: 'Select the probation team',
-        },
-        {
-          href: '#officerDetailsOrUnknown',
-          text: "Enter the probation officer's details",
-        },
-        {
-          href: '#meetingType',
-          text: 'Select the meeting type',
-        },
-      ])
-    } else {
-      expect(result).toEqual([])
-    }
+    expect(result).toEqual([
+      {
+        href: '#probationTeam',
+        text: 'Select the probation team',
+      },
+      {
+        href: '#officerDetailsOrUnknown',
+        text: "Enter the probation officer's details",
+      },
+      {
+        href: '#meetingType',
+        text: 'Select the meeting type',
+      },
+    ])
   })
 
   it('should fail validation when both not yet known selected and some officer details entered', async () => {
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerDetailsNotKnown: toggle ? 'true' : undefined,
-      officerFullName: toggle ? 'Test name' : undefined,
-      officerEmail: toggle ? 'Test email' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerDetailsNotKnown: 'true',
+      officerFullName: 'Test name',
+      officerEmail: 'Test email',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(futureDate, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -121,27 +112,23 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
 
     const result = AppointmentValidator(appointmentForm)
 
-    if (toggle) {
-      expect(result).toEqual([
-        {
-          href: '#officerDetailsOrUnknown',
-          text: "Enter either the probation officer's details, or select 'Not yet known'",
-        },
-      ])
-    } else {
-      expect(result).toEqual([])
-    }
+    expect(result).toEqual([
+      {
+        href: '#officerDetailsOrUnknown',
+        text: "Enter either the probation officer's details, or select 'Not yet known'",
+      },
+    ])
   })
 
   it('should fail validation when officer details are not entered', async () => {
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerFullName: toggle ? '' : undefined,
-      officerEmail: toggle ? '' : undefined,
-      officerTelephone: toggle ? '07777777777' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerFullName: '',
+      officerEmail: '',
+      officerTelephone: '07777777777',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(futureDate, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -155,31 +142,27 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
 
     const result = AppointmentValidator(appointmentForm)
 
-    if (toggle) {
-      expect(result).toEqual([
-        {
-          href: '#officerFullName',
-          text: "Enter the probation officer's full name",
-        },
-        {
-          href: '#officerEmail',
-          text: "Enter the probation officer's email address",
-        },
-      ])
-    } else {
-      expect(result).toEqual([])
-    }
+    expect(result).toEqual([
+      {
+        href: '#officerFullName',
+        text: "Enter the probation officer's full name",
+      },
+      {
+        href: '#officerEmail',
+        text: "Enter the probation officer's email address",
+      },
+    ])
   })
 
   it('should fail validation when for an invalid email and phone number', async () => {
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerFullName: toggle ? 'Test name' : undefined,
-      officerEmail: toggle ? 'invalid' : undefined,
-      officerTelephone: toggle ? 'invalid' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerFullName: 'Test name',
+      officerEmail: 'invalid',
+      officerTelephone: 'invalid',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(futureDate, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -193,20 +176,16 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
 
     const result = AppointmentValidator(appointmentForm)
 
-    if (toggle) {
-      expect(result).toEqual([
-        {
-          href: '#officerEmail',
-          text: "'Enter a valid email address'",
-        },
-        {
-          href: '#officerTelephone',
-          text: 'Enter a valid UK phone number',
-        },
-      ])
-    } else {
-      expect(result).toEqual([])
-    }
+    expect(result).toEqual([
+      {
+        href: '#officerEmail',
+        text: "'Enter a valid email address'",
+      },
+      {
+        href: '#officerTelephone',
+        text: 'Enter a valid UK phone number',
+      },
+    ])
   })
 
   it('should fail validation with bad data', async () => {
@@ -267,10 +246,10 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
   it('should fail validation with date beyond a year in the future', async () => {
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerDetailsNotKnown: toggle ? 'true' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerDetailsNotKnown: 'true',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(futureDateYear, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -297,10 +276,10 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
     const dayBeforeFutureDateYear = formatDateISO(subDays(new Date(futureDateYear), 1))
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerDetailsNotKnown: toggle ? 'true' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerDetailsNotKnown: 'true',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(dayBeforeFutureDateYear, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',
@@ -400,10 +379,10 @@ describe.each([[true], [false]])('Validation middleware - VLPM feature toggle %s
     const nextWeekendDate = formatDateISO(addDays(new Date(), 6 - new Date().getDay() || 7))
     const appointmentForm = {
       appointmentType: 'VLPM',
-      probationTeam: toggle ? 'TEAM_CODE' : undefined,
+      probationTeam: 'TEAM_CODE',
       location: '27000',
-      officerDetailsNotKnown: toggle ? 'true' : undefined,
-      meetingType: toggle ? 'MEETING_TYPE' : undefined,
+      officerDetailsNotKnown: 'true',
+      meetingType: 'MEETING_TYPE',
       date: formatDate(nextWeekendDate, 'short'),
       startTimeHours: '10',
       startTimeMinutes: '30',

--- a/server/validators/appointmentValidator.ts
+++ b/server/validators/appointmentValidator.ts
@@ -4,7 +4,6 @@ import { isValidPhoneNumber } from 'libphonenumber-js'
 import { Validator } from '../middleware/validationMiddleware'
 import HmppsError from '../interfaces/HmppsError'
 import { calculateEndDate, formatDate, formatDateISO, isRealDate, parseDate } from '../utils/dateHelpers'
-import { bvlsMasteredVlpmFeatureToggleEnabled } from '../utils/featureToggles'
 
 export const AppointmentValidator: Validator = (body: Record<string, string>) => {
   const errors: HmppsError[] = []
@@ -22,7 +21,7 @@ export const AppointmentValidator: Validator = (body: Record<string, string>) =>
     })
   }
 
-  if (bvlsMasteredVlpmFeatureToggleEnabled() && body.appointmentType === 'VLPM' && !body.probationTeam) {
+  if (body.appointmentType === 'VLPM' && !body.probationTeam) {
     errors.push({
       text: 'Select the probation team',
       href: '#probationTeam',
@@ -36,7 +35,7 @@ export const AppointmentValidator: Validator = (body: Record<string, string>) =>
     })
   }
 
-  if (bvlsMasteredVlpmFeatureToggleEnabled() && body.appointmentType === 'VLPM') {
+  if (body.appointmentType === 'VLPM') {
     const hasOfficerDetails = !!(body.officerFullName || body.officerEmail || body.officerTelephone)
     const isUnknownSelected = !!body.officerDetailsNotKnown
 

--- a/server/validators/prePostAppointmentValidator.test.ts
+++ b/server/validators/prePostAppointmentValidator.test.ts
@@ -1,11 +1,6 @@
 import { PrePostAppointmentValidator } from './prePostAppointmentValidator'
-import config from '../config'
 
 describe('Validation middleware', () => {
-  beforeEach(() => {
-    config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled = true
-  })
-
   it('should pass validation with good data', async () => {
     const vlbForm = {
       preAppointment: 'no',
@@ -88,47 +83,5 @@ describe('Validation middleware', () => {
     expect(result).toEqual([
       { text: 'Enter a court hearing link which is 120 characters or less', href: '#videoLinkUrl' },
     ])
-  })
-
-  describe('VLPM feature toggle off', () => {
-    beforeEach(() => {
-      config.featureToggles.bvlsMasteredVlpmFeatureToggleEnabled = false
-    })
-
-    it('should fail validation for booking type missing', async () => {
-      const vlbForm = {
-        bookingType: '',
-      }
-
-      const result = PrePostAppointmentValidator(vlbForm)
-
-      expect(result).toEqual([
-        {
-          href: '#bookingType',
-          text: 'Select a booking type',
-        },
-      ])
-    })
-
-    it('should fail validation for meeting type and probation team missing', async () => {
-      const vlbForm = {
-        bookingType: 'PROBATION',
-        probationTeam: '',
-        meetingType: '',
-      }
-
-      const result = PrePostAppointmentValidator(vlbForm)
-
-      expect(result).toEqual([
-        {
-          href: '#probationTeam',
-          text: 'Select which probation team the meeting is with',
-        },
-        {
-          href: '#meetingType',
-          text: 'Select the meeting type',
-        },
-      ])
-    })
   })
 })

--- a/server/validators/prePostAppointmentValidator.ts
+++ b/server/validators/prePostAppointmentValidator.ts
@@ -1,12 +1,11 @@
 import { Validator } from '../middleware/validationMiddleware'
 import HmppsError from '../interfaces/HmppsError'
-import { bvlsMasteredVlpmFeatureToggleEnabled } from '../utils/featureToggles'
 
 // eslint-disable-next-line import/prefer-default-export
 export const PrePostAppointmentValidator: Validator = (body: Record<string, string>) => {
   const errors: HmppsError[] = []
 
-  if ((bvlsMasteredVlpmFeatureToggleEnabled() || body.bookingType === 'COURT') && !body.preAppointment) {
+  if (!body.preAppointment) {
     errors.push({
       text: 'Select if a room is needed for the pre-court hearing briefing',
       href: '#preAppointment',
@@ -17,7 +16,7 @@ export const PrePostAppointmentValidator: Validator = (body: Record<string, stri
     errors.push({ text: 'Select a room for the pre-court hearing briefing', href: '#preAppointmentLocation' })
   }
 
-  if ((bvlsMasteredVlpmFeatureToggleEnabled() || body.bookingType === 'COURT') && !body.postAppointment) {
+  if (!body.postAppointment) {
     errors.push({
       text: 'Select if a room is needed for the post-court hearing briefing',
       href: '#postAppointment',
@@ -28,27 +27,15 @@ export const PrePostAppointmentValidator: Validator = (body: Record<string, stri
     errors.push({ text: 'Select a room for the post-court hearing briefing', href: '#postAppointmentLocation' })
   }
 
-  if (!bvlsMasteredVlpmFeatureToggleEnabled() && !body.bookingType) {
-    errors.push({ text: 'Select a booking type', href: '#bookingType' })
-  }
-
-  if ((bvlsMasteredVlpmFeatureToggleEnabled() || body.bookingType === 'COURT') && !body.court) {
+  if (!body.court) {
     errors.push({ text: 'Select which court the hearing is for', href: '#court' })
   }
 
-  if (!bvlsMasteredVlpmFeatureToggleEnabled() && body.bookingType === 'PROBATION' && !body.probationTeam) {
-    errors.push({ text: 'Select which probation team the meeting is with', href: '#probationTeam' })
-  }
-
-  if ((bvlsMasteredVlpmFeatureToggleEnabled() || body.bookingType === 'COURT') && !body.hearingType) {
+  if (!body.hearingType) {
     errors.push({ text: 'Select the hearing type', href: '#hearingType' })
   }
 
-  if (!bvlsMasteredVlpmFeatureToggleEnabled() && body.bookingType === 'PROBATION' && !body.meetingType) {
-    errors.push({ text: 'Select the meeting type', href: '#meetingType' })
-  }
-
-  if ((bvlsMasteredVlpmFeatureToggleEnabled() || body.bookingType === 'COURT') && !body.cvpRequired) {
+  if (!body.cvpRequired) {
     errors.push({ text: 'Select if you know the court hearing link', href: '#cvpRequired' })
   }
 

--- a/server/views/pages/appointments/addAppointment.njk
+++ b/server/views/pages/appointments/addAppointment.njk
@@ -92,9 +92,7 @@
                     {# When editing a video link booking you cannot change the type of appointment, or the probation team - display only #}
                     {% if appointmentId %}
                         <input type="hidden" id="appointmentType" name="appointmentType" value="{{ formValues.appointmentType }}" />
-                        {% if bvlsMasteredVlpmFeatureToggleEnabled() %}
-                            <input type="hidden" id="probationTeam" name="probationTeam" value="{{ formValues.probationTeam }}" />
-                        {% endif %}
+                        <input type="hidden" id="probationTeam" name="probationTeam" value="{{ formValues.probationTeam }}" />
                         {{ govukSummaryList({
                             classes: "govuk-summary-list--no-border",
                             rows: [
@@ -114,7 +112,7 @@
                                         text: (probationTeams | find('value', formValues.probationTeam)).text
                                     },
                                     classes: 'js-probation-team'
-                                } if bvlsMasteredVlpmFeatureToggleEnabled()
+                                }
                             ]
                         }) }}
                     {% else %}
@@ -129,21 +127,19 @@
                             items: appointmentTypes | addDefaultSelectedValue('Select appointment type') | setSelected(formValues.appointmentType)
                         }) }}
 
-                        {% if bvlsMasteredVlpmFeatureToggleEnabled() %}
-                            {{ govukSelect({
-                                id: "probationTeam",
-                                name: "probationTeam",
-                                label: {
-                                    text: "Select the probation team the booking is for"
-                                },
-                                formGroup : {
-                                    classes: "js-probation-team"
-                                },
-                                classes: 'govuk-!-width-one-half',
-                                errorMessage: errors | findError('probationTeam'),
-                                items: probationTeams | addDefaultSelectedValue('Select probation team') | setSelected(formValues.probationTeam)
-                            }) }}
-                        {% endif %}
+                        {{ govukSelect({
+                            id: "probationTeam",
+                            name: "probationTeam",
+                            label: {
+                                text: "Select the probation team the booking is for"
+                            },
+                            formGroup : {
+                                classes: "js-probation-team"
+                            },
+                            classes: 'govuk-!-width-one-half',
+                            errorMessage: errors | findError('probationTeam'),
+                            items: probationTeams | addDefaultSelectedValue('Select probation team') | setSelected(formValues.probationTeam)
+                        }) }}
                     {% endif %}
 
                     {{ govukSelect({
@@ -157,96 +153,94 @@
                         items: locations | addDefaultSelectedValue('Select location') | setSelected(formValues.location)
                     }) }}
 
-                    {% if bvlsMasteredVlpmFeatureToggleEnabled() %}
-                        <div class="govuk-form-group js-probation-officer {{ 'govuk-form-group--error' if errors | findError("officerDetailsOrUnknown") }}">
-                            <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Enter the probation officer's details</legend>
-                                <p id="officerDetailsOrUnknown" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span>{{ (errors | findError("officerDetailsOrUnknown")).text }}</p>
-                                <p class="govuk-body">You can enter the details later if not yet known</p>
-                                {{ govukCheckboxes({
-                                    idPrefix: "officerDetailsNotKnown",
-                                    name: "officerDetailsNotKnown",
-                                    items: [
-                                        {
-                                            value: "true",
-                                            text: "Not yet known",
-                                            checked: formValues.officerDetailsNotKnown
-                                        },
-                                        {
-                                            divider: "or"
-                                        }
-                                    ],
-                                    errorMessage: errors | findError("officerDetailsNotKnown"),
-                                    formGroup: {
-                                        classes: 'govuk-!-margin-bottom-3'
+                    <div class="govuk-form-group js-probation-officer {{ 'govuk-form-group--error' if errors | findError("officerDetailsOrUnknown") }}">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Enter the probation officer's details</legend>
+                            <p id="officerDetailsOrUnknown" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span>{{ (errors | findError("officerDetailsOrUnknown")).text }}</p>
+                            <p class="govuk-body">You can enter the details later if not yet known</p>
+                            {{ govukCheckboxes({
+                                idPrefix: "officerDetailsNotKnown",
+                                name: "officerDetailsNotKnown",
+                                items: [
+                                    {
+                                        value: "true",
+                                        text: "Not yet known",
+                                        checked: formValues.officerDetailsNotKnown
                                     },
-                                    classes: "govuk-!-width-one-third"
-                                }) }}
+                                    {
+                                        divider: "or"
+                                    }
+                                ],
+                                errorMessage: errors | findError("officerDetailsNotKnown"),
+                                formGroup: {
+                                    classes: 'govuk-!-margin-bottom-3'
+                                },
+                                classes: "govuk-!-width-one-third"
+                            }) }}
 
-                                {{ govukInput({
-                                    id: "officerFullName",
-                                    name: "officerFullName",
-                                    label: {
-                                        text: "Full name"
-                                    },
-                                    errorMessage: errors | findError('officerFullName'),
-                                    formGroup: {
-                                        classes: 'govuk-!-margin-bottom-3'
-                                    },
-                                    classes: "govuk-!-width-one-half",
-                                    value: formValues.officerFullName
-                                }) }}
+                            {{ govukInput({
+                                id: "officerFullName",
+                                name: "officerFullName",
+                                label: {
+                                    text: "Full name"
+                                },
+                                errorMessage: errors | findError('officerFullName'),
+                                formGroup: {
+                                    classes: 'govuk-!-margin-bottom-3'
+                                },
+                                classes: "govuk-!-width-one-half",
+                                value: formValues.officerFullName
+                            }) }}
 
-                                {{ govukInput({
-                                    id: "officerEmail",
-                                    name: "officerEmail",
-                                    label: {
-                                        text: "Email address"
-                                    },
-                                    errorMessage: errors | findError('officerEmail'),
-                                    formGroup: {
-                                        classes: 'govuk-!-margin-bottom-3'
-                                    },
-                                    classes: "govuk-!-width-one-half",
-                                    value: formValues.officerEmail
-                                }) }}
+                            {{ govukInput({
+                                id: "officerEmail",
+                                name: "officerEmail",
+                                label: {
+                                    text: "Email address"
+                                },
+                                errorMessage: errors | findError('officerEmail'),
+                                formGroup: {
+                                    classes: 'govuk-!-margin-bottom-3'
+                                },
+                                classes: "govuk-!-width-one-half",
+                                value: formValues.officerEmail
+                            }) }}
 
-                                {{ govukInput({
-                                    id: "officerTelephone",
-                                    name: "officerTelephone",
-                                    label: {
-                                        text: "UK phone number (optional)"
-                                    },
-                                    errorMessage: errors | findError('officerTelephone'),
-                                    classes: "govuk-input--width-10",
-                                    value: formValues.officerTelephone
-                                }) }}
-                            </fieldset>
-                        </div>
+                            {{ govukInput({
+                                id: "officerTelephone",
+                                name: "officerTelephone",
+                                label: {
+                                    text: "UK phone number (optional)"
+                                },
+                                errorMessage: errors | findError('officerTelephone'),
+                                classes: "govuk-input--width-10",
+                                value: formValues.officerTelephone
+                            }) }}
+                        </fieldset>
+                    </div>
 
-                        {# Replace OTHER to the end of the list #}
-                        {% set meetingTypes = meetingTypes | filterNot('value', 'OTHER') %}
-                        {% set meetingTypes = (meetingTypes.push({
-                            value: 'OTHER',
-                            text: 'Other'
-                        }), meetingTypes) %}
+                    {# Replace OTHER to the end of the list #}
+                    {% set meetingTypes = meetingTypes | filterNot('value', 'OTHER') %}
+                    {% set meetingTypes = (meetingTypes.push({
+                        value: 'OTHER',
+                        text: 'Other'
+                    }), meetingTypes) %}
 
-                        {{ govukRadios({
-                            idPrefix: "meetingType",
-                            name: "meetingType",
-                            fieldset: {
-                                legend: {
-                                    text: "Select meeting type",
-                                    classes: "govuk-fieldset__legend--s"
-                                }
-                            },
-                            formGroup : {
-                                classes: "js-meeting-type"
-                            },
-                            items: meetingTypes | setChecked([formValues.meetingType]),
-                            errorMessage: errors | findError("meetingType")
-                        }) }}
-                    {% endif %}
+                    {{ govukRadios({
+                        idPrefix: "meetingType",
+                        name: "meetingType",
+                        fieldset: {
+                            legend: {
+                                text: "Select meeting type",
+                                classes: "govuk-fieldset__legend--s"
+                            }
+                        },
+                        formGroup : {
+                            classes: "js-meeting-type"
+                        },
+                        items: meetingTypes | setChecked([formValues.meetingType]),
+                        errorMessage: errors | findError("meetingType")
+                    }) }}
 
                     {{ hmppsDatepicker({
                         id: "date",

--- a/server/views/pages/appointments/appointmentConfirmation.njk
+++ b/server/views/pages/appointments/appointmentConfirmation.njk
@@ -46,7 +46,7 @@
                             value: {
                                 text: probationTeam
                             }
-                        } if bvlsMasteredVlpmFeatureToggleEnabled() and appointmentTypeCode == 'VLPM',
+                        } if appointmentTypeCode == 'VLPM',
                         {
                             key: {
                                 text: "Location",
@@ -63,7 +63,7 @@
                             value: {
                                 text: "Not yet known" if officerDetailsNotKnown else officerFullName
                             }
-                        } if bvlsMasteredVlpmFeatureToggleEnabled() and appointmentTypeCode == 'VLPM',
+                        } if appointmentTypeCode == 'VLPM',
                         {
                             key: {
                                 text: "Email address"
@@ -71,7 +71,7 @@
                             value: {
                                 text: "Not yet known" if officerDetailsNotKnown else officerEmail
                             }
-                        } if bvlsMasteredVlpmFeatureToggleEnabled() and appointmentTypeCode == 'VLPM',
+                        } if appointmentTypeCode == 'VLPM',
                         {
                             key: {
                                 text: "UK phone number",
@@ -80,7 +80,7 @@
                             value: {
                                 text: "Not yet known" if officerDetailsNotKnown else (officerTelephone or "None entered")
                             }
-                        } if bvlsMasteredVlpmFeatureToggleEnabled() and appointmentTypeCode == 'VLPM',
+                        } if appointmentTypeCode == 'VLPM',
                         {
                             key: {
                                 text: "Meeting type",
@@ -89,7 +89,7 @@
                             value: {
                                 text: meetingType
                             }
-                        } if bvlsMasteredVlpmFeatureToggleEnabled() and appointmentTypeCode == 'VLPM',
+                        } if appointmentTypeCode == 'VLPM',
                         {
                             key: {
                                 text: "Date"

--- a/server/views/pages/appointments/prePostAppointmentConfirmation.njk
+++ b/server/views/pages/appointments/prePostAppointmentConfirmation.njk
@@ -31,14 +31,14 @@
                 {% if mustContactTheCourt %}
                 {% set html %}
                   <h3 class="govuk-notification-banner__heading">
-                    You must email {{ probationTeam if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else court }} to confirm the booking.
+                    You must email {{ court }} to confirm the booking.
                   </h3>
                   <p class="govuk-body">This is because they do not yet have access to the Book a video link service.</p>
                 {% endset %}
 
                 {{ govukNotificationBanner({
                   html: html,
-                  titleText: 'Email ' + probationTeam if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else court + ' to confirm the booking'
+                  titleText: 'Email ' + court + ' to confirm the booking'
                 }) }}
                 {% endif %}
 
@@ -147,18 +147,18 @@
                     rows: [
                         {
                             key: {
-                                text: "Probation team" if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else "Court location"
+                                text: "Court location"
                             },
                             value: {
-                                text: probationTeam if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else court
+                                text: court
                             }
                         },
                         {
                             key: {
-                                text: "Meeting type" if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else "Hearing type"
+                                text: "Hearing type"
                             },
                             value: {
-                                text: meetingType if (bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled()) else hearingType
+                                text: hearingType
                             }
                         },
                         {
@@ -168,7 +168,7 @@
                             value: {
                                 text: videoLinkUrl or "Not yet known"
                             }
-                        } if bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled()
+                        }
                     ]
                 }) }}
 

--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -71,10 +71,10 @@
                     rows: [
                         {
                             key: {
-                                text: "Court" if (formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled()) else "Probation team"
+                                text: "Court"
                             },
                             value: {
-                                text: (courts | find('value', formValues.court)).text if (formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled()) else (probationTeams | find('value', formValues.probationTeam)).text
+                                text: (courts | find('value', formValues.court)).text
                             }
                         } if appointmentId,
                         {
@@ -96,7 +96,7 @@
                         },
                         {
                             key: {
-                                text: "Court hearing start time" if (formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled()) else "Probation meeting start time"
+                                text: "Court hearing start time"
                             },
                             value: {
                                 text: startTime
@@ -104,7 +104,7 @@
                         },
                         {
                             key: {
-                                text: "Court hearing end time" if (formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled()) else "Probation meeting end time"
+                                text: "Court hearing end time"
                             },
                             value: {
                                 text: endTime
@@ -127,85 +127,72 @@
                 <form method="post">
                     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                     <input type="hidden" id="date" name="date" value="{{ date }}"/>
-                    {% if not bvlsMasteredVlpmFeatureToggleEnabled() %}
-                        <input type="hidden" id="bookingType" name="bookingType" value="{{ formValues.bookingType or "COURT" }}"/>
-                    {% endif %}
 
-                    {% if formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled() %}
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full">
-                                {{ govukRadios({
-                                    idPrefix: "preAppointment",
-                                    name: "preAppointment",
-                                    errorMessage: errors | findError('preAppointment'),
-                                    fieldset: {
-                                        legend: {
-                                            text: "Do you want to add a pre-court hearing briefing?",
-                                            classes: "govuk-fieldset__legend--s"
-                                        }
-                                    },
-                                    items: [{
-                                        value: "yes",
-                                        text: "Yes",
-                                        checked: formValues.preAppointment == 'yes',
-                                        conditional: {
-                                            html: preAppointmentHtml
-                                        }
-                                    },
-                                        {
-                                            value: "no",
-                                            text: "No",
-                                            checked: formValues.preAppointment == 'no'
-                                        }
-                                    ]
-                                }) }}
-                            </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            {{ govukRadios({
+                                idPrefix: "preAppointment",
+                                name: "preAppointment",
+                                errorMessage: errors | findError('preAppointment'),
+                                fieldset: {
+                                    legend: {
+                                        text: "Do you want to add a pre-court hearing briefing?",
+                                        classes: "govuk-fieldset__legend--s"
+                                    }
+                                },
+                                items: [{
+                                    value: "yes",
+                                    text: "Yes",
+                                    checked: formValues.preAppointment == 'yes',
+                                    conditional: {
+                                        html: preAppointmentHtml
+                                    }
+                                },
+                                    {
+                                        value: "no",
+                                        text: "No",
+                                        checked: formValues.preAppointment == 'no'
+                                    }
+                                ]
+                            }) }}
                         </div>
+                    </div>
 
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-full">
-                                {{ govukRadios({
-                                    idPrefix: "postAppointment",
-                                    name: "postAppointment",
-                                    errorMessage: errors | findError('postAppointment'),
-                                    fieldset: {
-                                        legend: {
-                                            text: "Do you want to add a post-court hearing briefing?",
-                                            classes: "govuk-fieldset__legend--s"
-                                        }
-                                    },
-                                    items: [{
-                                        value: "yes",
-                                        text: "Yes",
-                                        checked: formValues.postAppointment == 'yes',
-                                        conditional: {
-                                            html: postAppointmentHtml
-                                        }
-                                    },
-                                        {
-                                            value: "no",
-                                            text: "No",
-                                            checked: formValues.postAppointment == 'no'
-                                        }
-                                    ]
-                                }) }}
-                            </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            {{ govukRadios({
+                                idPrefix: "postAppointment",
+                                name: "postAppointment",
+                                errorMessage: errors | findError('postAppointment'),
+                                fieldset: {
+                                    legend: {
+                                        text: "Do you want to add a post-court hearing briefing?",
+                                        classes: "govuk-fieldset__legend--s"
+                                    }
+                                },
+                                items: [{
+                                    value: "yes",
+                                    text: "Yes",
+                                    checked: formValues.postAppointment == 'yes',
+                                    conditional: {
+                                        html: postAppointmentHtml
+                                    }
+                                },
+                                    {
+                                        value: "no",
+                                        text: "No",
+                                        checked: formValues.postAppointment == 'no'
+                                    }
+                                ]
+                            }) }}
                         </div>
-                    {% else %}
-                        <input type="hidden" id="preAppointment" name="preAppointment" value="no"/>
-                        <input type="hidden" id="postAppointment" name="postAppointment" value="no"/>
-                    {% endif %}
+                    </div>
 
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             {% if appointmentId %}
                                 <span class="govuk-visually-hidden" id="appointment-id">{{ appointmentId }}</span>
-                                {% if formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled() %}
-                                    <input type="hidden" id="court" name="court" value="{{ formValues.court }}" />
-                                {% endif %}
-                                {% if formValues.bookingType == 'PROBATION' and not bvlsMasteredVlpmFeatureToggleEnabled() %}
-                                    <input type="hidden" id="court" name="probationTeam" value="{{ formValues.probationTeam }}" />
-                                {% endif %}
+                                <input type="hidden" id="court" name="court" value="{{ formValues.court }}" />
                             {% else %}
                                 {{ govukSelect({
                                     name: "court",
@@ -219,68 +206,55 @@
                                 }) }}
                             {% endif %}
 
-                            {% if formValues.bookingType != 'PROBATION' or bvlsMasteredVlpmFeatureToggleEnabled() %}
-                                {{ govukSelect({
-                                    name: "hearingType",
-                                    id: "hearingType",
+                            {{ govukSelect({
+                                name: "hearingType",
+                                id: "hearingType",
+                                label: {
+                                    text: "What is the hearing type?",
+                                    classes: 'govuk-!-font-weight-bold'
+                                },
+                                items: hearingTypes | addDefaultSelectedValue('Select hearing type') | setSelected(formValues.hearingType),
+                                errorMessage: errors | findError("hearingType")
+                            }) }}
+
+                            {% set courtHearingLinkHtml %}
+                                {{ govukInput({
+                                    name: "videoLinkUrl",
+                                    id: "videoLinkUrl",
                                     label: {
-                                        text: "What is the hearing type?",
-                                        classes: 'govuk-!-font-weight-bold'
+                                        text: "Court hearing link"
                                     },
-                                    items: hearingTypes | addDefaultSelectedValue('Select hearing type') | setSelected(formValues.hearingType),
-                                    errorMessage: errors | findError("hearingType")
+                                    value: formValues.videoLinkUrl,
+                                    errorMessage: errors | findError("videoLinkUrl")
                                 }) }}
+                            {% endset %}
 
-                                {% set courtHearingLinkHtml %}
-                                    {{ govukInput({
-                                        name: "videoLinkUrl",
-                                        id: "videoLinkUrl",
-                                        label: {
-                                            text: "Court hearing link"
-                                        },
-                                        value: formValues.videoLinkUrl,
-                                        errorMessage: errors | findError("videoLinkUrl")
-                                    }) }}
-                                {% endset %}
-
-                                {{ govukRadios({
-                                    idPrefix: "cvpRequired",
-                                    name: "cvpRequired",
-                                    errorMessage: errors | findError('cvpRequired'),
-                                    fieldset: {
-                                        legend: {
-                                            text: "Do you know the link for this video link hearing?",
-                                            classes: "govuk-fieldset__legend--s"
+                            {{ govukRadios({
+                                idPrefix: "cvpRequired",
+                                name: "cvpRequired",
+                                errorMessage: errors | findError('cvpRequired'),
+                                fieldset: {
+                                    legend: {
+                                        text: "Do you know the link for this video link hearing?",
+                                        classes: "govuk-fieldset__legend--s"
+                                    }
+                                },
+                                items: [
+                                    {
+                                        value: "yes",
+                                        text: "Yes",
+                                        checked: formValues.cvpRequired == 'yes',
+                                        conditional: {
+                                            html: courtHearingLinkHtml
                                         }
                                     },
-                                    items: [
-                                        {
-                                            value: "yes",
-                                            text: "Yes",
-                                            checked: formValues.cvpRequired == 'yes',
-                                            conditional: {
-                                                html: courtHearingLinkHtml
-                                            }
-                                        },
-                                        {
-                                            value: "no",
-                                            text: "No",
-                                            checked: formValues.cvpRequired == 'no'
-                                        }
-                                    ]
-                                }) }}
-                            {% else %}
-                                {{ govukSelect({
-                                    name: "meetingType",
-                                    id: "meetingType",
-                                    label: {
-                                        text: "What is the meeting type?",
-                                        classes: 'govuk-!-font-weight-bold'
-                                    },
-                                    items: meetingTypes | addDefaultSelectedValue('Select meeting type') | setSelected(formValues.meetingType),
-                                    errorMessage: errors | findError("meetingType")
-                                }) }}
-                            {% endif %}
+                                    {
+                                        value: "no",
+                                        text: "No",
+                                        checked: formValues.cvpRequired == 'no'
+                                    }
+                                ]
+                            }) }}
                         </div>
                     </div>
 


### PR DESCRIPTION
This change removes the master VLPM feature toggle from the service.

The code that was sitting behind it is now always used going forwards.  The old code is no longer needed so it has been removed. 