### PR TITLE
BAVL-806 the staff hint text needs to be differnt for probation and court appointments.  Also missed displaying of notes instead of comments on court journey if feature toggle is on.

### DIFF
--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -15,6 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const appointmentId = document.getElementById('appointment-id')?.value || ''
   const publicPrivateNotes = document.querySelector('.js-public-private-notes')
   const comments = document.querySelector('.js-comments')
+  const courtHintText = document.getElementById('court-hint-text')
+  const probationHintText = document.getElementById('probation-hint-text')
 
   async function getEventsForLocation() {
     const date = appointmentDateInput.value
@@ -95,6 +97,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (appointmentType === 'VLB' || appointmentType === 'VLPM') {
       comments.style.display = 'none'
+
+      if (appointmentType === 'VLB') {
+        courtHintText.removeAttribute("style");
+        probationHintText.style.display = 'none'
+      } else {
+        probationHintText.removeAttribute("style");
+        courtHintText.style.display = 'none'
+      }
+
       publicPrivateNotes.removeAttribute("style");
     } else {
       comments.removeAttribute("style");

--- a/server/views/pages/appointments/addAppointment.njk
+++ b/server/views/pages/appointments/addAppointment.njk
@@ -337,7 +337,7 @@
                               text: "Notes for prison staff (optional)",
                               classes: 'govuk-fieldset__legend--s'
                             },
-                            hint: { text: "This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required." },
+                            hint: { html: "<p id='court-hint-text' class='govuk-hint'>This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details.</p><p id='probation-hint-text' class='govuk-hint'>This can include any additional information the prison staff need to know about the booking. For example, interpreter details if required.</p>" },
                             maxlength: "400"
                         }) }}
                         {{ govukCharacterCount({

--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -113,6 +113,29 @@
                     ]
                 }) }}
 
+                {% if bvlsMasterPublicPrivateNotesEnabled() %}
+                    {{ govukSummaryList({
+                        classes: 'govuk-summary-list--no-border appointment-details-list',
+                        rows: [
+                            {
+                                key: {
+                                    text: "Notes for prison staff"
+                                },
+                                value: {
+                                    text: notesForStaff
+                                }
+                            },
+                            {
+                                key: {
+                                    text: "Notes for prisoner"
+                                },
+                                value: {
+                                    text: notesForPrisoners
+                                }
+                            }
+                        ]
+                    }) }}
+                {% else %}
                 <dl class="govuk-summary-list govuk-summary-list--no-border appointment-details-list">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
@@ -123,6 +146,7 @@
                         </dd>
                     </div>
                 </dl>
+                {% endif %}
 
                 <form method="post">
                     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />


### PR DESCRIPTION
Show different `notes for staff` hint text for court appointments and probation appointments.

Due to the dynamic nature of this page we have to do this with JavaScript.

![court-appointment-hint-text](https://github.com/user-attachments/assets/883b21ce-7b5a-48cb-8d38-b10bf247d110)

![probation-appointment-hint-txt](https://github.com/user-attachments/assets/45edd28d-7398-4e24-bba2-2474137e1a3a)
