### PR TITLE
BAVL-900 small content changes for the BVLS court and probation appointment notes journeys.

### DIFF
--- a/server/views/pages/appointments/appointmentConfirmation.njk
+++ b/server/views/pages/appointments/appointmentConfirmation.njk
@@ -166,7 +166,7 @@
                                 text: "Notes for prison staff"
                             },
                             value: {
-                                text: notesForStaff
+                                text: notesForStaff or 'None entered'
                             }
                         },
                         {
@@ -174,7 +174,7 @@
                                 text: "Notes for prisoner"
                             },
                             value: {
-                                text: notesForPrisoners
+                                text: notesForPrisoners or 'None entered'
                             }
                         }
                     ]

--- a/server/views/pages/appointments/prePostAppointmentConfirmation.njk
+++ b/server/views/pages/appointments/prePostAppointmentConfirmation.njk
@@ -106,7 +106,7 @@
                                     text: "Notes for prison staff"
                                 },
                                 value: {
-                                    text: notesForStaff
+                                    text: notesForStaff or 'None entered'
                                 }
                             },
                             {
@@ -114,7 +114,7 @@
                                     text: "Notes for prisoner"
                                 },
                                 value: {
-                                    text: notesForPrisoners
+                                    text: notesForPrisoners or 'None entered'
                                 }
                             }
                         ]

--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -122,7 +122,7 @@
                                     text: "Notes for prison staff"
                                 },
                                 value: {
-                                    text: notesForStaff
+                                    text: notesForStaff or 'None entered'
                                 }
                             },
                             {
@@ -130,7 +130,7 @@
                                     text: "Notes for prisoner"
                                 },
                                 value: {
-                                    text: notesForPrisoners
+                                    text: notesForPrisoners or 'None entered'
                                 }
                             }
                         ]


### PR DESCRIPTION
Small change for add appointment for BVLS court and probation to display 'None entered' for notes when nothing entered.