### PR TITLE
CDPS-1376: Updating moj-frontend to 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-sqs": "^3.812.0",
         "@contentful/rich-text-html-renderer": "^17.0.0",
         "@contentful/rich-text-types": "^16.8.5",
-        "@ministryofjustice/frontend": "^2.2.5",
+        "@ministryofjustice/frontend": "^3.7.2",
         "@ministryofjustice/hmpps-auth-clients": "^0.0.1-alpha.4",
         "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "@ministryofjustice/hmpps-connect-dps-shared-items": "^1.2.1",
@@ -2468,19 +2468,17 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-2.2.5.tgz",
-      "integrity": "sha512-UR8WTME0vrYhtCxBESd0XaAvfjdi9UujieeooQj1ddQKdcfI/wkXUMJO8hWWvXjeqRxfKB2v62rw1mSRc+Yqrw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.7.2.tgz",
+      "integrity": "sha512-px1xC2wnY2JxGspbv+CSFpONvcPzlDs0WICXlktgGkd/1P08pXv8Kprt7YCvRZN4idxXBAkuLX5Um3G4YYpkUQ==",
       "license": "MIT",
-      "dependencies": {
-        "govuk-frontend": "^5.0.0",
-        "moment": "^2.27.0"
-      },
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "jquery": "^3.6.0"
+        "govuk-frontend": "5.x",
+        "jquery": "3.x",
+        "moment": "2.x"
       }
     },
     "node_modules/@ministryofjustice/hmpps-auth-clients": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@aws-sdk/client-sqs": "^3.812.0",
     "@contentful/rich-text-html-renderer": "^17.0.0",
     "@contentful/rich-text-types": "^16.8.5",
-    "@ministryofjustice/frontend": "^2.2.5",
+    "@ministryofjustice/frontend": "^3.7.2",
     "@ministryofjustice/hmpps-auth-clients": "^0.0.1-alpha.4",
     "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "@ministryofjustice/hmpps-connect-dps-shared-items": "^1.2.1",


### PR DESCRIPTION
I needed the alert component introduced in 3.4.0.  I've checked the breaking changes in https://github.com/ministryofjustice/moj-frontend/releases/tag/v3.0.0 and there's nothing there that affects us.