### PR TITLE
BAVL-919 small error message change to be consistent with BVLS and DPS services for notes.

### DIFF
--- a/server/validators/appointmentValidator.test.ts
+++ b/server/validators/appointmentValidator.test.ts
@@ -60,8 +60,8 @@ describe('Validation middleware - VLPM appointment', () => {
     const result = AppointmentValidator(appointmentForm)
 
     expect(result).toEqual([
-      { text: 'Enter notes for staff using 400 characters or less', href: '#notesForStaff' },
-      { text: 'Enter notes for prisoners using 400 characters or less', href: '#notesForPrisoners' },
+      { text: 'Notes for prison staff must be 400 characters or less', href: '#notesForStaff' },
+      { text: 'Notes for prisoner must be 400 characters or less', href: '#notesForPrisoners' },
     ])
   })
 
@@ -90,8 +90,8 @@ describe('Validation middleware - VLPM appointment', () => {
     const result = AppointmentValidator(appointmentForm)
 
     expect(result).toEqual([
-      { text: 'Enter notes for staff using 400 characters or less', href: '#notesForStaff' },
-      { text: 'Enter notes for prisoners using 400 characters or less', href: '#notesForPrisoners' },
+      { text: 'Notes for prison staff must be 400 characters or less', href: '#notesForStaff' },
+      { text: 'Notes for prisoner must be 400 characters or less', href: '#notesForPrisoners' },
     ])
   })
 

--- a/server/validators/appointmentValidator.ts
+++ b/server/validators/appointmentValidator.ts
@@ -278,13 +278,13 @@ export const AppointmentValidator: Validator = (body: Record<string, string>) =>
   if ((body.appointmentType === 'VLPM' || body.appointmentType === 'VLB') && bvlsMasterPublicPrivateNotesEnabled()) {
     if (body.notesForStaff && body.notesForStaff.length > 400) {
       errors.push({
-        text: 'Enter notes for staff using 400 characters or less',
+        text: 'Notes for prison staff must be 400 characters or less',
         href: '#notesForStaff',
       })
     }
     if (body.notesForPrisoners && body.notesForPrisoners.length > 400) {
       errors.push({
-        text: 'Enter notes for prisoners using 400 characters or less',
+        text: 'Notes for prisoner must be 400 characters or less',
         href: '#notesForPrisoners',
       })
     }


### PR DESCRIPTION
Small error message tidy up for consistency across services where BVLS bookings can be created.

**Court journey:**
![court](https://github.com/user-attachments/assets/5bd1d3f7-0b9e-48ae-90b2-ed24f727955a)

**Probation journey:**
![probation](https://github.com/user-attachments/assets/6a747f07-de18-4fa5-a9c9-eb2ce83124e1)
