### PR TITLE
CDPS-1466: Hide 'Add UK Military service details' when prisoner not in caseload

### DIFF
--- a/server/controllers/personal/personalController.ts
+++ b/server/controllers/personal/personalController.ts
@@ -140,6 +140,7 @@ export default class PersonalController {
         personalRelationshipsApiReadEnabled,
         hasPersonalId,
         hasHomeOfficeId,
+        prisonerIsInCaseload: prisonerData.prisonId === activeCaseLoadId,
       })
     }
   }

--- a/server/views/partials/personalPage/personalDetails.njk
+++ b/server/views/partials/personalPage/personalDetails.njk
@@ -245,7 +245,7 @@
           </dl>
       {% endif %}
 
-      {% if militaryHistoryEnabled and militaryRecords.length === 0 %}
+      {% if militaryHistoryEnabled and militaryRecords.length === 0 and prisonerIsInCaseload %}
         <h3 class="govuk-!-font-size-24 govuk-!-margin-top-6 govuk-!-margin-bottom-3">Additional details</h3>
         <div class="govuk-!-margin-bottom-4">
           <a href="/prisoner/{{ prisonerNumber }}/personal/military-service-information" class="govuk-link govuk-link--no-visited-state"


### PR DESCRIPTION
It 404's when you get there because of caseload check failures. Since it's raised as a bug I figured hiding it in that case is the correct solution.