### PR TITLE
BAVL-902 small content fix for the guest pin radio and video link label.

### DIFF
--- a/server/views/pages/appointments/prePostAppointments.njk
+++ b/server/views/pages/appointments/prePostAppointments.njk
@@ -285,7 +285,7 @@
                                 errorMessage: errors | findError('cvpRequired'),
                                 fieldset: {
                                     legend: {
-                                        text: "Do you know the link for this video link hearing?",
+                                        text: "Do you know the video link for this hearing?",
                                         classes: "govuk-fieldset__legend--s"
                                     }
                                 },
@@ -320,9 +320,6 @@
                                             text: "Enter guest pin",
                                             classes: 'govuk-label--s'
                                         },
-                                        hint: {
-                                            text: "Some meetings require a guest pin for security reasons"
-                                        },
                                         inputmode: "numeric",
                                         classes: 'govuk-input--width-10',
                                         errorMessage: errors | findError('guestPin'),
@@ -339,6 +336,9 @@
                                             text: "Is a guest pin required?",
                                             classes: "govuk-fieldset__legend--s"
                                         }
+                                    },
+                                    hint: {
+                                        text: "Some meetings require a guest pin for security reasons"
                                     },
                                     items: [
                                         {


### PR DESCRIPTION
Small context fix for BVLS appointments:

Before:
![dps-before](https://github.com/user-attachments/assets/ff3be541-1a52-4487-98b1-85c6b49840fa)

After:
![dps-after](https://github.com/user-attachments/assets/5294b89f-649e-403c-8419-887a3d415039)
