### PR TITLE
INC-1396 Refactor incentives service to use prisonerNumber instead of bookingId

### DIFF
--- a/integration_tests/mockApis/incentivesMockApi.ts
+++ b/integration_tests/mockApis/incentivesMockApi.ts
@@ -2,11 +2,11 @@ import { stubFor } from './wiremock'
 import { incentiveReviewsMock } from '../../server/data/localMockData/incentiveReviewsMock'
 
 export default {
-  stubGetReviews: (bookingId: number) => {
+  stubGetReviews: (prisonerNumber: string) => {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/incentives/incentive-reviews/booking/${bookingId}`,
+        urlPattern: `/incentives/incentive-reviews/prisoner/${prisonerNumber}`,
       },
       response: {
         status: 200,

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -57,7 +57,7 @@ Cypress.Commands.add(
     cy.task('stubAccountBalances', bookingId)
     cy.task('stubAdjudications', bookingId)
     cy.task('stubGetCaseNoteCount', bookingId)
-    cy.task('stubGetReviews', bookingId)
+    cy.task('stubGetReviews', prisonerNumber)
     cy.task('stubVisitSummary', bookingId)
     cy.task('stubVisitBalances', prisonerNumber)
     cy.task('stubAssessments', bookingId)

--- a/server/controllers/overviewController.ts
+++ b/server/controllers/overviewController.ts
@@ -115,7 +115,7 @@ export default class OverviewController {
         : null,
       this.prisonerScheduleService.getScheduleOverview(clientToken, bookingId),
       isGranted(PrisonerIncentivesPermission.read, prisonerPermissions)
-        ? this.incentivesService.getIncentiveOverview(clientToken, bookingId)
+        ? this.incentivesService.getIncentiveOverview(clientToken, prisonerNumber)
         : null,
       Result.wrap(this.personalPageService.getLearnerNeurodivergence(prisonId, prisonerNumber), apiErrorCallback),
       this.prisonerScheduleService.getScheduledTransfers(clientToken, prisonerNumber),

--- a/server/data/incentivesApiClient.test.ts
+++ b/server/data/incentivesApiClient.test.ts
@@ -25,10 +25,10 @@ describe('caseNotesApiClient', () => {
 
   describe('getReviews', () => {
     it('Should return data from the API', async () => {
-      const bookingId = 123456
-      mockSuccessfulIncentivesApiCall(`/incentive-reviews/booking/${bookingId}`, incentiveReviewsMock)
+      const prisonerNumber = 'A1234AB'
+      mockSuccessfulIncentivesApiCall(`/incentive-reviews/prisoner/${prisonerNumber}`, incentiveReviewsMock)
 
-      const output = await incentivesApiClient.getReviews(bookingId)
+      const output = await incentivesApiClient.getReviews(prisonerNumber)
       expect(output).toEqual(incentiveReviewsMock)
     })
   })

--- a/server/data/incentivesApiClient.ts
+++ b/server/data/incentivesApiClient.ts
@@ -10,9 +10,9 @@ export default class IncentivesApiRestClient implements IncentivesApiClient {
     this.restClient = new RestClient('Incentives API', config.apis.incentivesApi, token)
   }
 
-  async getReviews(bookingId: number): Promise<IncentiveReviews> {
+  async getReviews(prisonerNumber: string): Promise<IncentiveReviews> {
     return this.restClient.get<IncentiveReviews>({
-      path: `/incentive-reviews/booking/${bookingId}`,
+      path: `/incentive-reviews/prisoner/${prisonerNumber}`,
       ignore404: true,
     })
   }

--- a/server/data/interfaces/incentivesApi/IncentiveReviews.ts
+++ b/server/data/interfaces/incentivesApi/IncentiveReviews.ts
@@ -1,4 +1,5 @@
 export default interface IncentiveReviews {
   iepDate: string
   nextReviewDate: string
+  bookingId: number
 }

--- a/server/data/interfaces/incentivesApi/incentivesApiClient.ts
+++ b/server/data/interfaces/incentivesApi/incentivesApiClient.ts
@@ -1,5 +1,5 @@
 import IncentiveReviews from './IncentiveReviews'
 
 export interface IncentivesApiClient {
-  getReviews(bookingId: number): Promise<IncentiveReviews>
+  getReviews(prisonerNumber: string): Promise<IncentiveReviews>
 }

--- a/server/data/localMockData/incentiveReviewsMock.ts
+++ b/server/data/localMockData/incentiveReviewsMock.ts
@@ -3,4 +3,5 @@ import IncentiveReviews from '../interfaces/incentivesApi/IncentiveReviews'
 export const incentiveReviewsMock: IncentiveReviews = {
   iepDate: '2023-01-01',
   nextReviewDate: '2024-01-01',
+  bookingId: 123456,
 }

--- a/server/services/incentivesService.test.ts
+++ b/server/services/incentivesService.test.ts
@@ -31,7 +31,7 @@ describe('prisonerScheduleService', () => {
 
     it('should get data and map incentive summary data', async () => {
       incentivesApiClient.getReviews = jest.fn().mockResolvedValue(incentiveReviewsMock)
-      const result = await service.getIncentiveOverview('token', 1)
+      const result = await service.getIncentiveOverview('token', 'A1234AB')
 
       expect(result).toEqual({
         daysOverdue: 2,
@@ -44,7 +44,7 @@ describe('prisonerScheduleService', () => {
     it('should return null if no data', async () => {
       incentivesApiClient.getReviews = jest.fn().mockResolvedValue(null)
 
-      const result = await service.getIncentiveOverview('token', 1)
+      const result = await service.getIncentiveOverview('token', 'A1234AB')
       expect(result).toEqual({
         daysOverdue: null,
         negativeBehaviourCount: null,
@@ -56,7 +56,7 @@ describe('prisonerScheduleService', () => {
     it('should return error object if api errors', async () => {
       incentivesApiClient.getReviews = jest.fn().mockRejectedValue('error')
 
-      const result = await service.getIncentiveOverview('token', 1)
+      const result = await service.getIncentiveOverview('token', 'A1234AB')
       expect(result).toEqual({ error: true })
     })
   })

--- a/server/services/incentivesService.ts
+++ b/server/services/incentivesService.ts
@@ -12,27 +12,27 @@ export default class IncentivesService {
     private readonly prisonApiClientBuilder: RestClientBuilder<PrisonApiClient>,
   ) {}
 
-  async getIncentiveOverview(clientToken: string, bookingId: number): Promise<IncentiveSummary | { error: true }> {
+  async getIncentiveOverview(clientToken: string, prisonerNumber: string): Promise<IncentiveSummary | { error: true }> {
     const incentivesApiClient = this.incentivesApiClientBuilder(clientToken)
     const prisonApiClient = this.prisonApiClientBuilder(clientToken)
 
     // TODO use the RESULT type for this
     try {
-      const incentiveReviews = await incentivesApiClient.getReviews(bookingId)
+      const incentiveReviews = await incentivesApiClient.getReviews(prisonerNumber)
 
       if (!incentiveReviews)
         return { positiveBehaviourCount: null, negativeBehaviourCount: null, nextReviewDate: null, daysOverdue: null }
 
       const [positiveBehaviourCount, negativeBehaviourCount] = await Promise.all([
         prisonApiClient.getCaseNoteCount(
-          bookingId,
+          incentiveReviews.bookingId,
           CaseNoteType.PositiveBehaviour,
           CaseNoteSubType.IncentiveEncouragement,
           incentiveReviews?.iepDate,
           formatDateISO(new Date()),
         ),
         prisonApiClient.getCaseNoteCount(
-          bookingId,
+          incentiveReviews.bookingId,
           CaseNoteType.NegativeBehaviour,
           CaseNoteSubType.IncentiveWarning,
           incentiveReviews?.iepDate,


### PR DESCRIPTION
Refactors the incentives service to replace the use of `bookingId` with `prisonerNumber` for improved consistency and clarity across the service.