### PR TITLE
CDPS-1569 Increase default alerts API timeout to 5s

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -269,10 +269,10 @@ export default {
     alertsApi: {
       url: get('ALERTS_API_URL', 'http://localhost:8082', requiredInProduction),
       timeout: {
-        response: Number(get('ALERTS_API_TIMEOUT_RESPONSE', 3000)),
-        deadline: Number(get('ALERTS_API_TIMEOUT_DEADLINE', 3000)),
+        response: Number(get('ALERTS_API_TIMEOUT_RESPONSE', 5000)),
+        deadline: Number(get('ALERTS_API_TIMEOUT_DEADLINE', 5000)),
       },
-      agent: new AgentConfig(Number(get('ALERTS_API_TIMEOUT_DEADLINE', 3000))),
+      agent: new AgentConfig(Number(get('ALERTS_API_TIMEOUT_DEADLINE', 5000))),
     },
     personIntegrationApi: {
       url: get('PERSON_INTEGRATION_API_URL', 'http://localhost:8082', requiredInProduction),


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/hmpps-alerts-api/pull/337 which decreases the access token timeout in the alerts API.
Worst case scenario for a successful access token in the alerts API is now 4s (2s connect + 2s timeout), so the timeout in the profile needs to exceed this.