### PR TITLE
MAP-2779 Remove `assessmentAgencyId` check from CSRA assessment filter

### DIFF
--- a/server/services/csraService.ts
+++ b/server/services/csraService.ts
@@ -49,9 +49,7 @@ export default class CsraService {
       if (filters.from && parseDate(filters.from) > csraDate) return false
       if (filters.to && parseDate(filters.to) < csraDate) return false
       if (filters.csra && !csraFilters.includes(classificationCode)) return false
-      if (filters.location && !locationFilters.includes(assessmentAgencyId)) return false
-
-      return true
+      return !(filters.location && !locationFilters.includes(assessmentAgencyId))
     })
   }
 


### PR DESCRIPTION
This pull request removes the redundant check for `assessmentAgencyId` in the CSRA assessment filter, streamlining the evaluation process.