### PR TITLE
BAVL-1074: Suppress comments from movement slips for 4 video appointment types

### DIFF
--- a/assets/js/addAppointment.js
+++ b/assets/js/addAppointment.js
@@ -15,6 +15,7 @@ const publicPrivateNotes = document.querySelector('.js-public-private-notes')
 const comments = document.querySelector('.js-comments')
 const courtHintText = document.getElementById('court-hint-text')
 const probationHintText = document.getElementById('probation-hint-text')
+const optionalVideoLabel = document.getElementById('optional-video-label')
 
 async function getEventsForLocation() {
   const date = appointmentDateInput.value
@@ -92,6 +93,16 @@ function showHideProbationFields() {
   }
 }
 
+function showHideVideoLabel() {
+  const appointmentType = appointmentTypeSelect.value
+
+  if (appointmentType && ['VLOO', 'VLLA', 'VLPA', 'VLAP'].includes(appointmentType)) {
+    optionalVideoLabel.style.display = 'block'
+  } else {
+    optionalVideoLabel.style.display = 'none'
+  }
+}
+
 function showHidePublicPrivateNotes() {
   if (!publicPrivateNotes) {
     return
@@ -121,6 +132,7 @@ appointmentTypeSelect.addEventListener('change', () => {
   showHideRecurring()
   showHideProbationFields()
   showHidePublicPrivateNotes()
+  showHideVideoLabel()
 })
 
 appointmentLocationSelect.addEventListener('change', () => {
@@ -154,4 +166,5 @@ document.addEventListener('DOMContentLoaded', function () {
   showHideRecurring()
   showHideProbationFields()
   showHidePublicPrivateNotes()
+  showHideVideoLabel()
 })

--- a/server/views/pages/appointments/addAppointment.njk
+++ b/server/views/pages/appointments/addAppointment.njk
@@ -310,6 +310,10 @@
                         ]
                     }) }}
 
+                  <div id="optional-video-label" class="govuk-label">
+                    <p>For confidentiality reasons, comments for some video appointments will not appear on prisoner movement slips.</p>
+                  </div>
+
                     <div class="js-comments">
                     {{ govukTextarea({
                         name: "comments",

--- a/server/views/pages/appointments/movementSlips.njk
+++ b/server/views/pages/appointments/movementSlips.njk
@@ -31,11 +31,14 @@
             {{ labelAndValue('Moving to', location) }}
             {{ labelAndValue('Reason', appointmentType) }}
 
-            {# BVLS appointments show the notes for prisoners if enabled, otherwise suppress the comments #}
-            {% if (appointmentTypeCode == 'VLB' or appointmentTypeCode == 'VLPM') %}
+            {% if (appointmentTypeCode in ['VLB', 'VLPM']) %}
+                {# BVLS appointments show only the notes for prisoners on movement slips #}
                 {{ labelAndValue('Comments', notesForPrisoners, true) }}
+            {% elif appointmentTypeCode in ['VLOO', 'VLLA', 'VLAP', 'VLPA'] %}
+              {# Non-BVLS video appointments suppress comments from movement slips #}
+              {{ labelAndValue('Comments', '', true) }}
             {% else %}
-                {# All other appointment types show the comment from the appointment #}
+                {# All other appointment types show the comments on movement slips #}
                 {{ labelAndValue('Comments', comment, true) }}
             {% endif %}
         </div>


### PR DESCRIPTION
Of the 6 video appointment types, 2 are mastered in BVLS, and already collect separate staff and prisoner comments.

* VLB - video link court hearing
* VLPM - video link probation meeting

The 4 others are standard appointments and only have a single comments field, and are seen as a higher risk to potentially share external party names and contact details in their comments.

* VLLA - video link legal appointment
* VLPA - video link parole appointment
* VLOO - video link official other
* VLAP - video link with another prison.

This PR suppresses the comments on prisoner movement slips for these 4 appointment types.