### PR TITLE
CDPS-1447 Update personal page column widths

### DIFF
--- a/assets/scss/components/_personal-distinguishing-marks.scss
+++ b/assets/scss/components/_personal-distinguishing-marks.scss
@@ -1,8 +1,10 @@
 .personal-distinguishing-marks {
-  display: flex;
+  display: grid;
+  grid-template-columns: 30% 70%;
+  grid-column-gap: 20px;
   flex-wrap: wrap;
-  column-gap: 50px;
   margin-bottom: 15px;
+  padding-right: 20px;
 
   dl {
     margin: 0;
@@ -107,14 +109,8 @@
     }
   }
 
-  &__info {
-    flex: 2;
-  }
-
   &__image-container {
     position: relative;
-    flex: 1;
-    flex-basis: 10%;
     height: fit-content;
 
     @media (max-width: 768px) {
@@ -155,21 +151,21 @@
       position: absolute;
       top: calc(10.65% + 20px);
       left: 19%;
-      width: 9.2%;
+      width: 9.3%;
     }
 
     .dm-overlay-torso {
       position: absolute;
       top: calc(13.25% + 20px);
       left: 8.7%;
-      width: 29.7%;
+      width: 29.8%;
     }
 
     .dm-overlay-right-arm {
       position: absolute;
       top: calc(15.95% + 20px);
       left: 0;
-      width: 11.3%;
+      width: 11.5%;
     }
 
     .dm-overlay-right-hand {
@@ -183,7 +179,7 @@
       position: absolute;
       top: calc(15.95% + 20px);
       left: 35.8%;
-      width: 11.3%;
+      width: 11.5%;
     }
 
     .dm-overlay-left-hand {
@@ -195,37 +191,37 @@
 
     .dm-overlay-right-leg {
       position: absolute;
-      top: calc(45.4% + 13px);
+      top: calc(45.4% + 12px);
       left: 9.4%;
-      width: 14.4%;
+      width: 14.6%;
     }
 
     .dm-overlay-right-foot {
       position: absolute;
       top: calc(89.4% + 3px);
       left: 12.4%;
-      width: 8.85%;
+      width: 8.95%;
     }
 
     .dm-overlay-left-leg {
       position: absolute;
-      top: calc(45.4% + 13px);
+      top: calc(45.4% + 12px);
       left: 23.4%;
-      width: 14.4%;
+      width: 14.6%;
     }
 
     .dm-overlay-left-foot {
       position: absolute;
       top: calc(89.4% + 3px);
       left: 26.1%;
-      width: 8.85%;
+      width: 8.95%;
     }
 
     .dm-overlay-back {
       position: absolute;
       top: calc(13.25% + 20px);
       left: 61.3%;
-      width: 29.6%;
+      width: 29.8%;
     }
   }
 }

--- a/assets/scss/pages/_personal.scss
+++ b/assets/scss/pages/_personal.scss
@@ -58,6 +58,14 @@
     }
   }
 
+  .govuk-summary-list__key {
+    width: 30%;
+  }
+
+  .govuk-summary-list__actions {
+    width: 13%;
+  }
+
   .govuk-summary-list .govuk-summary-list__value.govuk-summary-list--sub-list--bottom-border {
     padding-top: 15px;
     padding-right: 20px;


### PR DESCRIPTION
As part of this, I've also tweaked the distinguishing marks overlay images to fill the outline a bit better.

Before:
<img width="543" height="662" alt="Screenshot 2025-09-17 at 17 33 59" src="https://github.com/user-attachments/assets/c416a993-770e-42d6-bfdb-e820b4d045e6" />

After:
<img width="431" height="535" alt="Screenshot 2025-09-17 at 17 34 13" src="https://github.com/user-attachments/assets/38116a80-6cae-4077-b2e8-3f40b6ae636f" />

