### PR TITLE
CDPS-1394: Express 5 compatibility

### DIFF
--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -1,9 +1,9 @@
 import type { Express } from 'express'
 import request from 'supertest'
 import { DataAccess } from './data'
-import CommonApiRoutes from './routes/common/api'
 import { appWithAllRoutes } from './routes/testutils/appSetup'
 import { aliasServiceMock } from '../tests/mocks/aliasServiceMock'
+import { commonApiRoutesMock } from '../tests/mocks/comonApiRoutesMock'
 import AliasService from './services/aliasService'
 
 jest.mock('./services')
@@ -14,7 +14,7 @@ beforeEach(() => {
   app = appWithAllRoutes({
     services: {
       dataAccess: {} as DataAccess,
-      commonApiRoutes: {} as CommonApiRoutes,
+      commonApiRoutes: commonApiRoutesMock(),
       aliasService: aliasServiceMock() as AliasService,
     },
   })

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -13,7 +13,7 @@ export default function createErrorHandler(production: boolean) {
     error: HTTPError | NotFoundError | ServerError | RoleError | SanitisedError,
     req: Request,
     res: Response,
-    next: NextFunction,
+    _next: NextFunction,
   ): void => {
     if (error instanceof NotFoundError && error.hmppsStatus !== HmppsStatusCode.NOT_FOUND) {
       logger.warn(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error.message)

--- a/server/middleware/apiErrorMiddleware.ts
+++ b/server/middleware/apiErrorMiddleware.ts
@@ -1,14 +1,13 @@
 import type { RequestHandler } from 'express'
-import asyncMiddleware from './asyncMiddleware'
 import logger from '../../logger'
 
 export default function apiErrorMiddleware(): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (_req, res, next) => {
     res.locals.apiErrorCallback = (error: Error) => {
       logger.error(error)
       res.locals.pageHasApiErrors = true
     }
 
     return next()
-  })
+  }
 }

--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -2,10 +2,9 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
@@ -19,5 +18,5 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/server/middleware/flashMessageMiddleware.ts
+++ b/server/middleware/flashMessageMiddleware.ts
@@ -1,11 +1,10 @@
 import type { RequestHandler } from 'express'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function flashMessageMiddleware(): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     const flashMessage = req.flash('flashMessage')
     res.locals.flashMessage = flashMessage?.length ? flashMessage[0] : undefined
 
     return next()
-  })
+  }
 }

--- a/server/middleware/retrieveCuriousInPrisonCourses.ts
+++ b/server/middleware/retrieveCuriousInPrisonCourses.ts
@@ -1,13 +1,12 @@
-import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { RequestHandler } from 'express'
 import CuriousService from '../services/curiousService'
-import asyncMiddleware from './asyncMiddleware'
 import { InPrisonCourseRecords } from '../services/interfaces/curiousService/CuriousInPrisonCourses'
 
 /**
  *  Middleware function that returns a Request handler function to look up the prisoner's In Prison Courses from Curious
  */
 const retrieveCuriousInPrisonCourses = (curiousService: CuriousService): RequestHandler => {
-  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+  return async (req, res, next) => {
     const { prisonerNumber } = req.params
 
     // Lookup the prisoners In Prison Courses and store in res.locals if its either not there, or is for a different prisoner
@@ -23,7 +22,7 @@ const retrieveCuriousInPrisonCourses = (curiousService: CuriousService): Request
       )
     }
     next()
-  })
+  }
 }
 
 export default retrieveCuriousInPrisonCourses

--- a/server/routes/imageRouter.ts
+++ b/server/routes/imageRouter.ts
@@ -72,7 +72,7 @@ export default function imageRouter(services: Services): Router {
     getPrisonerData(services),
     prisonerPermissionsGuard(prisonPermissionsService, { requestDependentOn: [CorePersonRecordPermission.read_photo] }),
     buildBreadcrumbsAndReferer(),
-    async (req, res, next) => {
+    async (req, res) => {
       const { prisonerNumber, miniBannerData, clientToken } = getCommonRequestData(req, res)
       const { prisonerData, inmateDetail, alertSummaryData } = req.middleware
       const { activeCaseLoadId } = res.locals.user as PrisonUser

--- a/server/routes/routerUtils.ts
+++ b/server/routes/routerUtils.ts
@@ -1,20 +1,13 @@
 import { RequestHandler, Router } from 'express'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 
 const getRequest =
   (router: Router) =>
   (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.get(
-      path,
-      handlers.map(handler => asyncMiddleware(handler)),
-    )
+    router.get(path, ...handlers)
 
 const postRequest =
   (router: Router) =>
   (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.post(
-      path,
-      handlers.map(handler => asyncMiddleware(handler)),
-    )
+    router.post(path, ...handlers)
 
 export { getRequest, postRequest }

--- a/tests/mocks/comonApiRoutesMock.ts
+++ b/tests/mocks/comonApiRoutesMock.ts
@@ -1,0 +1,10 @@
+import CommonApiRoutes from '../../server/routes/common/api'
+
+export const commonApiRoutesMock = () =>
+  ({
+    distinguishingMarkImage: jest.fn(),
+    image: jest.fn(),
+    prisonerImage: jest.fn(),
+  }) as unknown as CommonApiRoutes
+
+export default { commonApiRoutesMock }


### PR DESCRIPTION
`asyncMiddleware` is not needed since express 5 can already deal with thrown exceptions inside request handlers. cf. [template project](https://github.com/ministryofjustice/hmpps-template-typescript/pull/560) removed it during the upgrade