### PR TITLE
Fix integration tests using wiremock to serve an image

### DIFF
--- a/integration_tests/mockApis/personIntegrationApi.ts
+++ b/integration_tests/mockApis/personIntegrationApi.ts
@@ -1,4 +1,10 @@
-import { stubGetWithBody, stubPatchWithResponse, stubPostWithResponse, stubPutWithResponse } from './utils'
+import {
+  loadFileAsBase64,
+  stubGetWithBody,
+  stubPatchWithResponse,
+  stubPostWithResponse,
+  stubPutWithResponse,
+} from './utils'
 import {
   AddressResponseDto,
   ContactsResponseDto,
@@ -109,7 +115,7 @@ export default {
         headers: {
           'Content-Type': 'image/jpeg',
         },
-        bodyFileName: placeHolderImagePath,
+        base64Body: loadFileAsBase64(placeHolderImagePath),
       },
     })
   },

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -87,7 +87,7 @@ import { visitPrisonsMock } from '../../server/data/localMockData/visitPrisons'
 import VisitWithVisitors from '../../server/data/interfaces/prisonApi/VisitWithVisitors'
 import { VisitsListQueryParams } from '../../server/data/interfaces/prisonApi/PagedList'
 import { CaseNoteSummaryByTypesParams } from '../../server/data/interfaces/prisonApi/prisonApiClient'
-import { stubGetWithBody } from './utils'
+import { loadFileAsBase64, stubGetWithBody } from './utils'
 
 const placeHolderImagePath = './../../assets/images/average-face.jpg'
 
@@ -219,7 +219,7 @@ export default {
         headers: {
           'Content-Type': 'image/png',
         },
-        bodyFileName: placeHolderImagePath,
+        base64Body: loadFileAsBase64(placeHolderImagePath),
       },
     })
   },
@@ -347,7 +347,7 @@ export default {
         headers: {
           'Content-Type': 'image/png',
         },
-        bodyFileName: placeHolderImagePath,
+        base64Body: loadFileAsBase64(placeHolderImagePath),
       },
     })
   },

--- a/integration_tests/mockApis/utils.ts
+++ b/integration_tests/mockApis/utils.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { resolve as resolvePath } from 'node:path'
+
 import { stubFor } from './wiremock'
 
 export function stubGetWithBody<T>({ path, body }: { path: string; body: T }) {
@@ -78,4 +81,8 @@ export function stubDeleteWithResponse<TResponse>({ path, responseBody }: { path
       jsonBody: responseBody,
     },
   })
+}
+
+export function loadFileAsBase64(path: string): string {
+  return readFileSync(resolvePath(__dirname, path), { encoding: 'base64' })
 }


### PR DESCRIPTION
The image path `./../../assets/images/average-face.jpg` is supposed to be relative to the mock api typescript file, but wiremock cannot know that – so it’s always absent.

Cf. errors in all “Run wiremock” and “Run the node app” steps on CircleCI.
>  Error when working with FileSource:
> "Access to file ./../../assets/images/average-face.jpg is not permitted. An absolute path from the filesystem root might be specified"

> WARN HMPPS Prisoner Profile: Error calling Prison API, path: '/api/bookings/offenderNo/G6123VU/image/data?fullSizeImage=false', verb: 'GET' (responseStatus=500, data={}, message="Internal Server Error")

Using `base64Body ` in place of `bodyFileName` means that wiremock can simple reserve the content it was provided with.