### PR TITLE
CDPS-1914 & CDPS-1922: Improve Sentry.io error reporting

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,8 +1,11 @@
+import type { Readable } from 'node:stream'
 import { ApiConfig, RestClient as HmppsRestClient, SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import { ErrorLogger } from '@ministryofjustice/hmpps-rest-client/dist/main/types/Errors'
-import { Readable } from 'stream'
+import * as Sentry from '@sentry/node'
 import CircuitBreaker from 'opossum'
 import appConfig from '../config'
+import { anonymise, anonymisedErrorMessage } from '../middleware/setUpSentry'
+import { getErrorStatus } from '../utils/errorHelpers'
 import logger, { warnLevelLogger } from '../../logger'
 
 interface ErrorHandler<Response, ErrorData> {
@@ -84,6 +87,38 @@ export default abstract class RestClient extends HmppsRestClient {
     }
   }
 
+  protected addSentryBreadcrumb(path: string, method: string, error: SanitisedError): void {
+    if (appConfig.sentry.dsn) {
+      const breadcrumb: Record<string, unknown> = {
+        api: this.name,
+        url: `${this.config.url}${anonymise(path)}`,
+        'http.method': method,
+        status_code: getErrorStatus(error) ?? 500,
+      }
+      const sanitisedError = anonymisedErrorMessage(error)
+      if (sanitisedError) {
+        breadcrumb.sanitisedError = sanitisedError
+      }
+      Sentry.addBreadcrumb({
+        type: 'http',
+        category: 'http',
+        level: 'error',
+        message: `${this.name} request failed`,
+        data: breadcrumb,
+      })
+    }
+  }
+
+  protected handleError<Response, ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): Response {
+    this.addSentryBreadcrumb(path, method, error)
+    return super.handleError(path, method, error)
+  }
+
+  protected logError<ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): void {
+    this.addSentryBreadcrumb(path, method, error)
+    return super.logError(path, method, error)
+  }
+
   // Overridden get function to enforce use of token and the circuit breaker
   async get<Response = unknown, ErrorData = unknown>(
     {
@@ -157,9 +192,11 @@ export default abstract class RestClient extends HmppsRestClient {
     return this.get<Response, ErrorData>(
       {
         ...options,
-        errorHandler: (_path, _method, error): null => {
-          if (error.responseStatus === 404) return null
-          throw error
+        errorHandler: (path, method, error): null => {
+          if (error.responseStatus === 404) {
+            return null
+          }
+          return this.handleError(path, method, error)
         },
       },
       this.token,
@@ -202,7 +239,7 @@ export default abstract class RestClient extends HmppsRestClient {
     })
   }
 
-  async requestMultipart<T>(
+  protected async requestMultipart<T>(
     method: 'POST' | 'PUT',
     {
       path = null,

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -1,11 +1,8 @@
 import type { Readable } from 'node:stream'
 import { ApiConfig, RestClient as HmppsRestClient, SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import { ErrorLogger } from '@ministryofjustice/hmpps-rest-client/dist/main/types/Errors'
-import * as Sentry from '@sentry/node'
 import CircuitBreaker from 'opossum'
 import appConfig from '../config'
-import { anonymise, anonymisedErrorMessage } from '../middleware/setUpSentry'
-import { getErrorStatus } from '../utils/errorHelpers'
 import logger, { warnLevelLogger } from '../../logger'
 
 interface ErrorHandler<Response, ErrorData> {
@@ -85,38 +82,6 @@ export default abstract class RestClient extends HmppsRestClient {
         tokenString: string,
       ) => super.get<unknown, unknown>(request, tokenString)
     }
-  }
-
-  protected addSentryBreadcrumb(path: string, method: string, error: SanitisedError): void {
-    if (appConfig.sentry.dsn) {
-      const breadcrumb: Record<string, unknown> = {
-        api: this.name,
-        url: `${this.config.url}${anonymise(path)}`,
-        'http.method': method,
-        status_code: getErrorStatus(error) ?? 500,
-      }
-      const sanitisedError = anonymisedErrorMessage(error)
-      if (sanitisedError) {
-        breadcrumb.sanitisedError = sanitisedError
-      }
-      Sentry.addBreadcrumb({
-        type: 'http',
-        category: 'http',
-        level: 'error',
-        message: `${this.name} request failed`,
-        data: breadcrumb,
-      })
-    }
-  }
-
-  protected handleError<Response, ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): Response {
-    this.addSentryBreadcrumb(path, method, error)
-    return super.handleError(path, method, error)
-  }
-
-  protected logError<ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): void {
-    this.addSentryBreadcrumb(path, method, error)
-    return super.logError(path, method, error)
   }
 
   // Overridden get function to enforce use of token and the circuit breaker

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import * as Sentry from '@sentry/node'
 import config from '../config'
-import { errorHasStatus } from '../utils/errorHelpers'
+import NotFoundError from '../utils/notFoundError'
 
 export function setUpSentry() {
   if (config.sentry.dsn) {
@@ -28,12 +28,14 @@ export function setUpSentry() {
 
       beforeSend(event, hint) {
         const error = hint.originalException
-        // ignore 404 errors, wherever they originate
-        if (errorHasStatus(error, 404)) {
+
+        // ignore 404 errors as long as they are explicitly thrown in application code
+        if (error instanceof NotFoundError) {
           return null
         }
+
+        // add extra context from third-party apis when available
         if (error instanceof SanitisedError && error.data) {
-          // add extra context from third-party apis when available
           const sanitisedError = anonymise(error.data.userMessage || error.data.developerMessage)
           if (sanitisedError) {
             event.contexts = {

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -34,11 +34,15 @@ export function setUpSentry() {
         }
         if (error instanceof SanitisedError && error.data) {
           // add extra context from third-party apis when available
-          event.contexts = {
-            ...event.contexts,
-            DPS: {
-              sanitisedError: error.data.userMessage ?? error.data.developerMessage,
-            },
+          const sanitisedError = anonymise(error.data.userMessage || error.data.developerMessage)
+          if (sanitisedError) {
+            event.contexts = {
+              ...event.contexts,
+              DPS: {
+                ...event.contexts?.DPS,
+                sanitisedError,
+              },
+            }
           }
         }
 
@@ -63,10 +67,10 @@ export function setUpSentry() {
   }
 }
 
-/** Replaces sensitive data in URL-like text, eg. transaction name and request url */
-export function anonymise(urlLike: string | undefined): string | undefined {
-  if (!urlLike) {
-    return urlLike
+/** Replaces sensitive data, eg. in event’s transaction name and request url */
+export function anonymise(text: string | undefined): string | undefined {
+  if (!text) {
+    return text
   }
   const replacements: [RegExp, string][] = [
     // prisoner number
@@ -75,12 +79,12 @@ export function anonymise(urlLike: string | undefined): string | undefined {
     // address autosuggest lookup
     [/\/api\/addresses\/find\/[A-Za-z0-9.+%' _-]+/, '/api/addresses/find/:query'],
   ]
-  return replacements.reduce((anonymisedUrlLike, [match, replacement]) => {
+  return replacements.reduce((anonymisedText, [match, replacement]) => {
     if (match.global) {
-      return anonymisedUrlLike.replaceAll(match, replacement)
+      return anonymisedText.replaceAll(match, replacement)
     }
-    return anonymisedUrlLike.replace(match, replacement)
-  }, urlLike)
+    return anonymisedText.replace(match, replacement)
+  }, text)
 }
 
 export function setUpSentryErrorHandler(app: express.Express): void {

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -35,8 +35,8 @@ export function setUpSentry() {
         }
 
         // add extra context from third-party apis when available
-        if (error instanceof SanitisedError && error.data) {
-          const sanitisedError = anonymise(error.data.userMessage || error.data.developerMessage)
+        if (error instanceof SanitisedError) {
+          const sanitisedError = anonymisedErrorMessage(error)
           if (sanitisedError) {
             event.contexts = {
               ...event.contexts,
@@ -87,6 +87,11 @@ export function anonymise(text: string | undefined): string | undefined {
     }
     return anonymisedText.replace(match, replacement)
   }, text)
+}
+
+export function anonymisedErrorMessage(error: SanitisedError): string | undefined {
+  const { data }: { data?: { userMessage?: string; developerMessage?: string } } = error
+  return data && anonymise(data.userMessage || data.developerMessage)
 }
 
 export function setUpSentryErrorHandler(app: express.Express): void {

--- a/server/middleware/setUpSentry.ts
+++ b/server/middleware/setUpSentry.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 
 import express from 'express'
+import superagent from 'superagent'
 import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import * as Sentry from '@sentry/node'
 import config from '../config'
@@ -36,7 +37,7 @@ export function setUpSentry() {
 
         // add extra context from third-party apis when available
         if (error instanceof SanitisedError) {
-          const sanitisedError = anonymisedErrorMessage(error)
+          const sanitisedError = anonymisedErrorMessage(error.data)
           if (sanitisedError) {
             event.contexts = {
               ...event.contexts,
@@ -66,6 +67,8 @@ export function setUpSentry() {
         return event
       },
     })
+
+    monkeyPatchSuperagent()
   }
 }
 
@@ -89,8 +92,8 @@ export function anonymise(text: string | undefined): string | undefined {
   }, text)
 }
 
-export function anonymisedErrorMessage(error: SanitisedError): string | undefined {
-  const { data }: { data?: { userMessage?: string; developerMessage?: string } } = error
+/** DPS apis often supply messages in the JSON response body */
+function anonymisedErrorMessage(data?: { userMessage?: string; developerMessage?: string }): string | undefined {
   return data && anonymise(data.userMessage || data.developerMessage)
 }
 
@@ -98,4 +101,60 @@ export function setUpSentryErrorHandler(app: express.Express): void {
   if (config.sentry.dsn) {
     Sentry.setupExpressErrorHandler(app)
   }
+}
+
+/** Sentry client does not automatically integrate into superagent */
+function monkeyPatchSuperagent(): void {
+  if ('__sentryPatch' in superagent) return
+
+  const endSuper = superagent.Request.prototype.end
+  superagent.Request.prototype.end = function end(callback) {
+    const req = this as superagent.Request
+    const { method, url: unsafeUrl } = req
+    const url = anonymise(unsafeUrl)
+
+    req.on('response', (res: superagent.Response) => {
+      const { status } = res
+      Sentry.addBreadcrumb({
+        type: 'http',
+        category: 'http',
+        level: typeof status !== 'number' || (status > 400 && status !== 404) ? 'error' : 'info',
+        message: `${method} ${url} ${status}`,
+        data: {
+          url,
+          'http.method': method,
+          status_code: status,
+        },
+      })
+    })
+
+    req.on('error', (error: Error | superagent.ResponseError | superagent.HTTPError) => {
+      const status = 'status' in error && error.status
+      const errorMessage =
+        ('response' in error &&
+          error.response &&
+          'body' in error.response &&
+          anonymisedErrorMessage(error.response.body)) ||
+        anonymise(error.message) ||
+        `Unknown ${error?.constructor?.name ?? 'error'}`
+      Sentry.addBreadcrumb({
+        type: 'http',
+        category: 'http',
+        level: 'error',
+        message: `${method} ${url} ${status}`,
+        data: {
+          url,
+          'http.method': method,
+          status_code: status,
+          error: errorMessage,
+        },
+      })
+    })
+
+    return endSuper.call(this, callback)
+  }
+
+  // @ts-expect-error monkey patch flag
+  // eslint-disable-next-line no-underscore-dangle
+  superagent.__sentryPatch = true
 }


### PR DESCRIPTION
- add breadcrumbs for all `superagent`-based requests
- report 404-type errors that are not thrown inside the application; ie. come from api calls
- anonymise reported error messages