### PR TITLE
CDPS-1915: Handle location history when a location is not a cell

### DIFF
--- a/server/services/prisonerLocationHistoryService.test.ts
+++ b/server/services/prisonerLocationHistoryService.test.ts
@@ -1,3 +1,4 @@
+import type { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import { WhereaboutsApiClient } from '../data/interfaces/whereaboutsApi/whereaboutsApiClient'
 import { prisonApiClientMock } from '../../tests/mocks/prisonApiClientMock'
@@ -161,7 +162,33 @@ describe('prisonerLocationHistoryService', () => {
 
     expect(nomisSyncPrisonerMappingApiClient.getMappingUsingNomisLocationId).toHaveBeenCalledWith(123456)
     expect(locationsInsidePrisonApiClient.getLocation).toHaveBeenCalledWith('abcdefg')
+    expect(locationsInsidePrisonApiClient.getLocationAttributes).toHaveBeenCalledWith('abcdefg')
     expect(res.locationAttributes).toEqual(locationAttributesForView)
+  })
+
+  it('Returns empty location attributes when looking up non-cell location in API ', async () => {
+    locationsInsidePrisonApiClient.getLocation = jest.fn().mockResolvedValue({
+      localName: 'Reception',
+      key: 'MDI-RECV',
+      specialistCellTypes: [],
+    })
+    locationsInsidePrisonApiClient.getLocationAttributes = jest
+      .fn()
+      .mockRejectedValue({ responseStatus: 404 } as SanitisedError)
+
+    const res = await service.getPrisonerLocationHistory(
+      'token',
+      PrisonerMockDataA,
+      'MDI',
+      '123457',
+      '2023-01-01',
+      '2024-01-01',
+    )
+
+    expect(nomisSyncPrisonerMappingApiClient.getMappingUsingNomisLocationId).toHaveBeenCalledWith(123457)
+    expect(locationsInsidePrisonApiClient.getLocation).toHaveBeenCalledWith('abcdefg')
+    expect(locationsInsidePrisonApiClient.getLocationAttributes).toHaveBeenCalledWith('abcdefg')
+    expect(res.locationAttributes).toEqual({ description: 'MDI-RECV', attributes: [] })
   })
 
   it('Should only include known specialist cell types', async () => {

--- a/server/services/prisonerLocationHistoryService.ts
+++ b/server/services/prisonerLocationHistoryService.ts
@@ -1,7 +1,9 @@
+import logger from '../../logger'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import Prisoner from '../data/interfaces/prisonerSearchApi/Prisoner'
 import { WhereaboutsApiClient } from '../data/interfaces/whereaboutsApi/whereaboutsApiClient'
 import HistoryForLocationItem from '../data/interfaces/prisonApi/HistoryForLocationItem'
+import { errorHasStatus } from '../utils/errorHelpers'
 import { formatName } from '../utils/utils'
 import { RestClientBuilder } from '../data'
 import CaseNotesApiClient from '../data/interfaces/caseNotesApi/caseNotesApiClient'
@@ -96,7 +98,14 @@ export default class PrisonerLocationHistoryService {
 
     const [location, locationAtrbts, locationHistory, agencyDetails, cellMoveReasonTypes] = await Promise.all([
       locationsInsidePrisonApiClient.getLocation(dpsLocationId),
-      locationsInsidePrisonApiClient.getLocationAttributes(dpsLocationId),
+      locationsInsidePrisonApiClient.getLocationAttributes(dpsLocationId).catch(error => {
+        if (errorHasStatus(error, 404)) {
+          // api returns 404 if location is not a cell
+          logger.warn(error, 'Cannot get location attributes')
+          return <never[]>[]
+        }
+        throw error
+      }),
       prisonApiClient.getHistoryForLocation(locationId, fromDate as string, toDate as string),
       prisonApiClient.getAgencyDetails(agencyId.toString()),
       prisonApiClient.getCellMoveReasonTypes(),


### PR DESCRIPTION
the locations-inside-prison api returns 404 when attributes are requested for a non-cell location so “View details” on a location history row threw an error for occasional locations (eg. reception).