### PR TITLE
CDPS-1924: Remove unnecessary API calls from photo requests

### DIFF
--- a/server/data/interfaces/prisonerSearchApi/Prisoner.ts
+++ b/server/data/interfaces/prisonerSearchApi/Prisoner.ts
@@ -124,6 +124,7 @@ export default interface Prisoner {
   marks?: BodyPartDetail[]
   newArrival24?: boolean
   newArrival72?: boolean
+  currentFacialImageId?: number
 }
 
 export interface Alias {

--- a/server/routes/common/api.ts
+++ b/server/routes/common/api.ts
@@ -23,11 +23,25 @@ export default class CommonApiRoutes {
     private readonly metricsService: MetricsService,
   ) {}
 
+  private async serveFacialImage(imageId: string, fullSizeImage: boolean, req: Request, res: Response) {
+    try {
+      const data = await this.offenderService.getImage(req.middleware.clientToken, imageId, fullSizeImage)
+      res.set('Cache-control', 'private, max-age=86400')
+      res.removeHeader('pragma')
+      res.type('image/jpeg')
+      data.pipe(res)
+    } catch {
+      res.redirect(placeHolderImage)
+    }
+  }
+
   public prisonerImage: RequestHandler = (req: Request, res: Response) => {
     const { prisonerNumber } = req.params
     const fullSizeImage = req.query.fullSizeImage ? req.query.fullSizeImage === 'true' : true
-    const { prisonerData, inmateDetail, alertSummaryData } = req.middleware
+    const { prisonerData } = req.middleware
     const { prisonerPermissions } = res.locals
+    const imageIdQuery = (req.query.imageId as string) || undefined
+    const currentFacialImageId = prisonerData.currentFacialImageId || undefined
 
     this.auditService
       .sendEvent({
@@ -39,23 +53,25 @@ export default class CommonApiRoutes {
       })
       .catch(error => logger.error(error))
 
-    // If there's no photo ID then we don't need to call the API and can prevent the extra call
-    const { placeholder } = this.photoService.getPhotoStatus(prisonerData, inmateDetail, alertSummaryData)
+    const imageQueryMatchesCurrent = imageIdQuery && currentFacialImageId && +imageIdQuery === currentFacialImageId
+    const hasPermission = isGranted(CorePersonRecordPermission.read_photo, prisonerPermissions)
 
-    if (placeholder || !isGranted(CorePersonRecordPermission.read_photo, prisonerPermissions)) {
-      res.redirect(placeHolderImage)
-    } else {
-      this.offenderService
-        .getPrisonerImage(req.middleware.clientToken, prisonerNumber, fullSizeImage)
-        .then(data => {
-          res.set('Cache-control', 'private, max-age=86400')
-          res.removeHeader('pragma')
-          res.type('image/jpeg')
-          data.pipe(res)
-        })
-        .catch(_error => {
+    if (hasPermission && imageQueryMatchesCurrent) {
+      this.serveFacialImage(imageIdQuery, fullSizeImage, req, res)
+    }
+
+    if (hasPermission && !imageQueryMatchesCurrent) {
+      this.photoService.getNewestActiveFacialImageId(prisonerNumber, req.middleware.clientToken).then(imageId => {
+        if (imageId) {
+          this.serveFacialImage(imageId.toString(), fullSizeImage, req, res)
+        } else {
           res.redirect(placeHolderImage)
-        })
+        }
+      })
+    }
+
+    if (!hasPermission) {
+      res.redirect(placeHolderImage)
     }
   }
 

--- a/server/routes/common/api.ts
+++ b/server/routes/common/api.ts
@@ -23,7 +23,7 @@ export default class CommonApiRoutes {
     private readonly metricsService: MetricsService,
   ) {}
 
-  private async serveFacialImage(imageId: string, fullSizeImage: boolean, req: Request, res: Response) {
+  private async streamFacialImage(imageId: string, fullSizeImage: boolean, req: Request, res: Response) {
     try {
       const data = await this.offenderService.getImage(req.middleware.clientToken, imageId, fullSizeImage)
       res.set('Cache-control', 'private, max-age=86400')
@@ -57,13 +57,13 @@ export default class CommonApiRoutes {
     const hasPermission = isGranted(CorePersonRecordPermission.read_photo, prisonerPermissions)
 
     if (hasPermission && imageQueryMatchesCurrent) {
-      this.serveFacialImage(imageIdQuery, fullSizeImage, req, res)
+      this.streamFacialImage(imageIdQuery, fullSizeImage, req, res)
     }
 
     if (hasPermission && !imageQueryMatchesCurrent) {
       this.photoService.getNewestActiveFacialImageId(prisonerNumber, req.middleware.clientToken).then(imageId => {
         if (imageId) {
-          this.serveFacialImage(imageId.toString(), fullSizeImage, req, res)
+          this.streamFacialImage(imageId.toString(), fullSizeImage, req, res)
         } else {
           res.redirect(placeHolderImage)
         }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -96,7 +96,7 @@ export default function routes(services: Services): Router {
   router.get(
     `/api${basePath}/image`,
     auditPageAccessAttempt({ services, page: ApiAction.PrisonerImage }),
-    getPrisonerData(services),
+    getPrisonerData(services, { minimal: true }),
     getDuplicatePrisonerData(services),
     prisonerPermissionsGuard(prisonPermissionsService, { requestDependentOn: [PrisonerBasePermission.read] }),
     services.commonApiRoutes.prisonerImage,

--- a/server/services/offenderService.ts
+++ b/server/services/offenderService.ts
@@ -14,8 +14,8 @@ export default class OffenderService {
     return this.prisonClientBuilder(token).getPrisonerImage(offenderNumber, fullSizeImage)
   }
 
-  getImage(token: string, imageId: string): Promise<Readable> {
-    return this.prisonClientBuilder(token).getImage(imageId, true)
+  getImage(token: string, imageId: string, fullSizeImage = true): Promise<Readable> {
+    return this.prisonClientBuilder(token).getImage(imageId, fullSizeImage)
   }
 
   async getPrisonerNonAssociationOverview(clientToken: string, prisonerNumber: string): Promise<NonAssociationSummary> {

--- a/server/services/photoService.test.ts
+++ b/server/services/photoService.test.ts
@@ -1,5 +1,6 @@
 import { prisonApiClientMock } from '../../tests/mocks/prisonApiClientMock'
 import { AlertSummaryData } from '../data/interfaces/alertsApi/Alert'
+import ImageDetails from '../data/interfaces/prisonApi/ImageDetails'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import { imageDetailListMock, imageDetailMock } from '../data/localMockData/imageMock'
 import { inmateDetailMock } from '../data/localMockData/inmateDetailMock'
@@ -108,6 +109,75 @@ describe('PhotoService', () => {
           alertSummaryData,
         ),
       ).toEqual({ withheld: false, placeholder: true })
+    })
+  })
+
+  describe('getNewestActiveFacialImageId', () => {
+    it('Returns the imageId of the active facial image', async () => {
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(prisonApiClient.getImagesForPrisoner).toHaveBeenCalledWith('A1234BC')
+      expect(res).toEqual(1680496)
+    })
+
+    it('Ignores non-facial images', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(
+        async () =>
+          [
+            { imageId: 1, imageView: 'SOMETHING_ELSE', active: true, captureDateTime: '2024-01-01T00:00:00' },
+            { imageId: 2, imageView: 'FACE', active: true, captureDateTime: '2023-01-01T00:00:00' },
+          ] as ImageDetails[],
+      )
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toEqual(2)
+    })
+
+    it('Ignores inactive facial images', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(
+        async () =>
+          [
+            { imageId: 1, imageView: 'FACE', active: false, captureDateTime: '2024-01-01T00:00:00' },
+            { imageId: 2, imageView: 'FACE', active: true, captureDateTime: '2023-01-01T00:00:00' },
+          ] as ImageDetails[],
+      )
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toEqual(2)
+    })
+
+    it('Returns the most recent when multiple active facial images exist (should not happen, though)', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(
+        async () =>
+          [
+            { imageId: 1, imageView: 'FACE', active: true, captureDateTime: '2022-01-01T00:00:00' },
+            { imageId: 2, imageView: 'FACE', active: true, captureDateTime: '2024-06-01T00:00:00' },
+            { imageId: 3, imageView: 'FACE', active: true, captureDateTime: '2023-03-01T00:00:00' },
+          ] as ImageDetails[],
+      )
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toEqual(2)
+    })
+
+    it('Returns undefined when there are no active facial images', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(
+        async () =>
+          [
+            { imageId: 1, imageView: 'FACE', active: false, captureDateTime: '2024-01-01T00:00:00' },
+            { imageId: 2, imageView: 'SOMETHING_ELSE', active: true, captureDateTime: '2023-01-01T00:00:00' },
+          ] as ImageDetails[],
+      )
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toBeUndefined()
+    })
+
+    it('Returns undefined when no images exist', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(async () => [] as ImageDetails[])
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toBeUndefined()
     })
   })
 })

--- a/server/services/photoService.test.ts
+++ b/server/services/photoService.test.ts
@@ -179,5 +179,14 @@ describe('PhotoService', () => {
       const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
       expect(res).toBeUndefined()
     })
+
+    it('Returns undefined when an error occurs', async () => {
+      prisonApiClient.getImagesForPrisoner = jest.fn(async () => {
+        throw new Error('Error fetching images')
+      })
+      service = new PhotoService(() => prisonApiClient)
+      const res = await service.getNewestActiveFacialImageId('A1234BC', 'clientToken')
+      expect(res).toBeUndefined()
+    })
   })
 })

--- a/server/services/photoService.ts
+++ b/server/services/photoService.ts
@@ -1,4 +1,4 @@
-import { compareDesc } from 'date-fns'
+import { compareAsc, compareDesc } from 'date-fns'
 import { RestClientBuilder } from '../data'
 import { PrisonApiClient } from '../data/interfaces/prisonApi/prisonApiClient'
 import { formatDateTime } from '../utils/dateHelpers'
@@ -43,5 +43,14 @@ export default class PhotoService {
         withheldPhotoCategoryCodes.includes(prisonerData.category) || alertSummaryData.highPublicInterestPrisoner,
       placeholder: !inmateDetail.facialImageId,
     }
+  }
+
+  async getNewestActiveFacialImageId(prisonerNumber: string, clientToken: string): Promise<number | undefined> {
+    const prisonApiClient = this.prisonApiClientBuilder(clientToken)
+    const images = await prisonApiClient.getImagesForPrisoner(prisonerNumber)
+    return images
+      .filter(i => i.imageView === 'FACE' && i.active) // Should only be one active. Just being safe.
+      .sort((a, b) => compareAsc(new Date(a.captureDateTime), new Date(b.captureDateTime)))
+      .pop()?.imageId
   }
 }

--- a/server/services/photoService.ts
+++ b/server/services/photoService.ts
@@ -46,11 +46,15 @@ export default class PhotoService {
   }
 
   async getNewestActiveFacialImageId(prisonerNumber: string, clientToken: string): Promise<number | undefined> {
-    const prisonApiClient = this.prisonApiClientBuilder(clientToken)
-    const images = await prisonApiClient.getImagesForPrisoner(prisonerNumber)
-    return images
-      .filter(i => i.imageView === 'FACE' && i.active) // Should only be one active. Just being safe.
-      .sort((a, b) => compareAsc(new Date(a.captureDateTime), new Date(b.captureDateTime)))
-      .pop()?.imageId
+    try {
+      const prisonApiClient = this.prisonApiClientBuilder(clientToken)
+      const images = await prisonApiClient.getImagesForPrisoner(prisonerNumber)
+      return images
+        .filter(i => i.imageView === 'FACE' && i.active) // Should only be one active. Just being safe.
+        .sort((a, b) => compareAsc(new Date(a.captureDateTime), new Date(b.captureDateTime)))
+        .pop()?.imageId
+    } catch {
+      return undefined
+    }
   }
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CDPS-1924

\+ currentFacialImageId?: number is now on the prisoner model, as we were using it as if it was already.
\- getPhotoStatus call is now not made unnecessarily.
\+ image id query parameter is now checked against currentFacialImageId and used to short-cut getting photo status.
\+ getNewestActiveFacialImageId method added to photo service. (all photo related things should move here in the future)
\+ test for photo service.
\+ getImage now accepts full size argument.
