### PR TITLE
CDPS-1932: Announce flash messages

### DIFF
--- a/assets/js/shared/flashMessage.ts
+++ b/assets/js/shared/flashMessage.ts
@@ -1,0 +1,38 @@
+import { Component } from 'govuk-frontend'
+
+/**
+ * Displays messages on the page that fade out after a brief period.
+ * Used with `req.flash('flashMessage', { text: '…' })` to indicate successful actions without using a GOV.UK Panel.
+ *
+ * Elements with the “alert” ARIA role only announce dynamic changes to content and not on load.
+ * Therefore this component creates a new element with the alert role and populates it after a sufficient pause.
+ */
+export class FlashMessage extends Component<HTMLDivElement> {
+  static moduleName = 'hmpps-flash-message'
+  static elementType = HTMLDivElement
+
+  constructor(root: HTMLDivElement) {
+    super(root)
+
+    // extract message and create alert element
+    const $p = root.querySelector('p')
+    const message = $p.textContent
+    $p.removeAttribute('role')
+    const $alertSpan = document.createElement('span')
+    $alertSpan.setAttribute('role', 'alert')
+
+    // re-insert message content after brief pause
+    setTimeout(() => {
+      $p.textContent = ''
+      $p.appendChild($alertSpan)
+      $alertSpan.innerText = message
+    }, 1_000)
+
+    // eventually, remove entire component
+    setTimeout(() => {
+      if (root.parentNode) {
+        root.parentNode.removeChild(root)
+      }
+    }, 15_000)
+  }
+}

--- a/assets/js/shared/index.ts
+++ b/assets/js/shared/index.ts
@@ -9,6 +9,7 @@ import { autocomplete } from './autocomplete'
 import { BackToTop } from './backToTop'
 import { BodyParts } from './bodyParts'
 import { fileUploadWithPreview } from './fileUploadWithPreview'
+import { FlashMessage } from './flashMessage'
 import { OpenCloseAll } from './openCloseAll'
 import { printPage } from './printPage'
 import { sortSelector } from './sortSelector'
@@ -17,7 +18,7 @@ govukFrontend.initAll()
 mojFrontend.initAll()
 connectDps.initAll()
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', () => {
   addAnotherButton()
   alertDynamicDropdowns()
   alertFlags()
@@ -27,5 +28,6 @@ document.addEventListener('DOMContentLoaded', function () {
   sortSelector()
   govukFrontend.createAll(BackToTop)
   govukFrontend.createAll(BodyParts)
+  govukFrontend.createAll(FlashMessage)
   govukFrontend.createAll(OpenCloseAll)
 })

--- a/assets/scss/components/_flash-message.scss
+++ b/assets/scss/components/_flash-message.scss
@@ -1,10 +1,6 @@
 @keyframes flashMessageFadeOut {
   0% {
     opacity: 1;
-    visibility: visible;
-  }
-  80% {
-    opacity: 1;
   }
   100% {
     opacity: 0;
@@ -16,8 +12,7 @@
   z-index: 1;
   top: 75px;
   left: 50%;
-  opacity: 0;
-  animation: flashMessageFadeOut 3s;
+  animation: 1s ease-out 4s both flashMessageFadeOut;
 
   &--at-anchor {
     position: fixed;
@@ -31,10 +26,10 @@
     justify-content: center;
     text-align: center;
     padding: 10px 30px;
-    margin-bottom: 0;
+    margin: 0;
     background-color: $govuk-success-colour;
     color: govuk-colour("white");
-    @include govuk-font($size: 19, $weight: 'bold');
+    @include govuk-font($size: 19, $weight: "bold");
 
     &::before {
       content: url("/assets/images/tick-icon.svg");

--- a/server/views/macros/hmppsFlashMessage.njk
+++ b/server/views/macros/hmppsFlashMessage.njk
@@ -1,0 +1,7 @@
+{% macro hmppsFlashMessage(params) -%}
+
+  <div class="hmpps-flash-message {% if params.anchored %}hmpps-flash-message--at-anchor{% endif %}" data-module="hmpps-flash-message">
+    <p role="alert">{{ params.text }}</p>
+  </div>
+
+{%- endmacro %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,6 +1,9 @@
+{% extends "govuk/template.njk" %}
+
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "macros/hmppsError.njk" import hmppsError %}
-{% extends "govuk/template.njk" %}
+{% from "macros/hmppsFlashMessage.njk" import hmppsFlashMessage %}
+
 {% block head %}
   {% include "./googleTagManagerHeadScripts.njk" %}
   {% include "./appInsightsWebTracking.njk" %}
@@ -33,9 +36,10 @@
   {% endif %}
 
   {% if flashMessage %}
-    <div class="hmpps-flash-message {{ 'hmpps-flash-message--at-anchor' if flashMessage.fieldName }}">
-      <p role="alert">{{ flashMessage.text }}</p>
-    </div>
+    {{ hmppsFlashMessage({
+      text: flashMessage.text,
+      anchored: flashMessage.fieldName
+    }) }}
   {% endif %}
 
   <div class="prisoner-profile-breadcrumbs govuk-!-display-none-print">


### PR DESCRIPTION
Elements already on the page at load time that have “alert” role are *not* assertively read out ahead of other content. So this change dynamically rejigs the flash message element structure to have the text read out after a brief pause. Delays in the tens of milliseconds do not get noticed, so using a more generous 1s.

Last attempt was #1464