### PR TITLE
Fixed missing breadcrumbs

### DIFF
--- a/server/views/pages/addresses/addresses.njk
+++ b/server/views/pages/addresses/addresses.njk
@@ -10,7 +10,7 @@
         href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     },
     {

--- a/server/views/pages/alerts/alertDetailsPage.njk
+++ b/server/views/pages/alerts/alertDetailsPage.njk
@@ -9,7 +9,7 @@
     href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     }
 ] %}

--- a/server/views/pages/appointments/prePostAppointmentConfirmation.njk
+++ b/server/views/pages/appointments/prePostAppointmentConfirmation.njk
@@ -12,7 +12,7 @@
         href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     }
 ] %}

--- a/server/views/pages/beliefHistory.njk
+++ b/server/views/pages/beliefHistory.njk
@@ -5,7 +5,7 @@
 {% set hideBackLink = true %}
 {% set breadCrumbs = [
     { text: 'Digital Prison Services', href:  "/" | prependBaseUrl },
-    { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber },
+    { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber },
     { text: 'Personal', href: "/prisoner/" + prisonerNumber + "/personal" }
 ] %}
 

--- a/server/views/pages/careNeeds/pastCareNeeds.njk
+++ b/server/views/pages/careNeeds/pastCareNeeds.njk
@@ -11,7 +11,7 @@
         href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     },
     {

--- a/server/views/pages/csra/csraReviewPage.njk
+++ b/server/views/pages/csra/csraReviewPage.njk
@@ -8,7 +8,7 @@
         href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     },
     {

--- a/server/views/pages/csra/prisonerCsraHistoryPage.njk
+++ b/server/views/pages/csra/prisonerCsraHistoryPage.njk
@@ -3,7 +3,7 @@
 
 {% set breadCrumbs = [
     { text: 'Digital Prison Services', href:  "/" | prependBaseUrl },
-    { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber }
+    { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber }
 ] %}
 
 {% block body %}

--- a/server/views/pages/duplicateProfiles.njk
+++ b/server/views/pages/duplicateProfiles.njk
@@ -12,7 +12,7 @@
     href:  "/" | prependBaseUrl
   },
   {
-    text: prisonerName.lastCommaFirst,
+    text: breadcrumbPrisonerName,
     href: "/prisoner/" + prisonerNumber
   }
 ] %}

--- a/server/views/pages/edit/editPage.njk
+++ b/server/views/pages/edit/editPage.njk
@@ -11,7 +11,7 @@
 {% set hideBackLink = true %}
 {% set breadCrumbs = [
     { text: 'Digital Prison Services', href:  "/" | prependBaseUrl },
-    { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber },
+    { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber },
     { text: 'Personal', href: "/prisoner/" + prisonerNumber + "/personal" }
   ] %}
 {% block body %}

--- a/server/views/pages/goals/vc2GoalsPage.njk
+++ b/server/views/pages/goals/vc2GoalsPage.njk
@@ -9,7 +9,7 @@
     href:  "/" | prependBaseUrl
   },
   {
-    text: prisonerName.lastCommaFirst,
+    text: breadcrumbPrisonerName,
     href: "/prisoner/" + prisonerNumber
   }
 ] %}

--- a/server/views/pages/locationDetails.njk
+++ b/server/views/pages/locationDetails.njk
@@ -14,7 +14,7 @@
     href:  "/" | prependBaseUrl
   },
   {
-    text: prisonerName.lastCommaFirst,
+    text: breadcrumbPrisonerName,
     href: "/prisoner/" + prisonerNumber
   }
 ] %}

--- a/server/views/pages/prisonerLocationHistory.njk
+++ b/server/views/pages/prisonerLocationHistory.njk
@@ -12,7 +12,7 @@
     href:  "/" | prependBaseUrl
   },
   {
-    text: prisonerName.lastCommaFirst,
+    text: breadcrumbPrisonerName,
     href: "/prisoner/" + prisonerNumber
   },
   {

--- a/server/views/pages/prisonerSchedule.njk
+++ b/server/views/pages/prisonerSchedule.njk
@@ -12,7 +12,7 @@
     href:  "/" | prependBaseUrl
   },
   {
-    text: prisonerName.lastCommaFirst,
+    text: breadcrumbPrisonerName,
     href: "/prisoner/" + prisonerNumber
   }
 ] %}

--- a/server/views/pages/probationDocuments/probationDocuments.njk
+++ b/server/views/pages/probationDocuments/probationDocuments.njk
@@ -11,7 +11,7 @@
 {% set hideBackLink = true %}
 {% set breadCrumbs = [
   { text: 'Digital Prison Services', href:  "/" | prependBaseUrl },
-  { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber }
+  { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber }
 ] %}
 
 {% macro summary(conviction) %}

--- a/server/views/pages/professionalContacts/professionalContactsPage.njk
+++ b/server/views/pages/professionalContacts/professionalContactsPage.njk
@@ -12,7 +12,7 @@
         href:  "/" | prependBaseUrl
     },
     {
-        text: prisonerName.lastCommaFirst,
+        text: breadcrumbPrisonerName,
         href: "/prisoner/" + prisonerNumber
     }
 ] %}

--- a/server/views/pages/visitsDetails.njk
+++ b/server/views/pages/visitsDetails.njk
@@ -5,7 +5,7 @@
 {%
   set breadCrumbs = [
   { text: 'Digital Prison Services', href:  "/" | prependBaseUrl },
-  { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber }
+  { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber }
   ]
 %}
 

--- a/server/views/pages/xrayBodyScans.njk
+++ b/server/views/pages/xrayBodyScans.njk
@@ -2,7 +2,7 @@
 {%
   set breadCrumbs = [
   { text: 'Digital Prison Services', href: '/' },
-  { text: prisonerName.lastCommaFirst, href: "/prisoner/" + prisonerNumber },
+  { text: breadcrumbPrisonerName, href: "/prisoner/" + prisonerNumber },
   { text: 'Personal', href: "/prisoner/" + prisonerNumber + "/personal"}
   ]
 %}


### PR DESCRIPTION
We noticed on the Visits page in the prisoner profile that the prisoners name (and associated link to their prisoner profile homepage) was missing from the breadcrumbs. Upon further investigation we noticed it also missing from other similar pages.

This PR updates the breadcrumb references on the affected pages.