### PR TITLE
IR-1681 Add Incident summary link to prisoner profile

### DIFF
--- a/integration_tests/e2e/overviewPage.cy.ts
+++ b/integration_tests/e2e/overviewPage.cy.ts
@@ -409,6 +409,11 @@ context('Overview Page', () => {
         const overviewPage = Page.verifyOnPage(OverviewPage)
         overviewPage.sideBar().moreInfo().socProfileInfoLink().should('not.exist')
       })
+
+      it('should display incident summary link', () => {
+        const overviewPage = Page.verifyOnPage(OverviewPage)
+        overviewPage.sideBar().moreInfo().incidentSummaryInfoLink().should('exist')
+      })
     })
   })
 

--- a/integration_tests/pages/overviewPage.ts
+++ b/integration_tests/pages/overviewPage.ts
@@ -142,6 +142,7 @@ export default class OverviewPage extends Page {
       probationDocumentsInfoLink: (): PageElement => cy.get('[data-qa=probation-documents-info-link]'),
       pathfinderProfileInfoLink: (): PageElement => cy.get('[data-qa=pathfinder-profile-info-link]'),
       socProfileInfoLink: (): PageElement => cy.get('[data-qa=soc-profile-info-link]'),
+      incidentSummaryInfoLink: (): PageElement => cy.get('[data-qa=incident-summary-info-link]'),
     }),
   })
 

--- a/server/controllers/utils/overviewController/buildOverviewInfoLinks.test.ts
+++ b/server/controllers/utils/overviewController/buildOverviewInfoLinks.test.ts
@@ -1,0 +1,47 @@
+import {
+  PathfinderPermission,
+  PrisonerPermissions,
+  ProbationDocumentsPermission,
+  SOCPermission,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
+import buildOverviewInfoLinks from './buildOverviewInfoLinks'
+import { PrisonerMockDataA } from '../../../data/localMockData/prisoner'
+import config from '../../../config'
+import mockPermissions from '../../../../tests/mocks/mockPermissions'
+
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib')
+
+const pathfinderNominal = { id: 1 }
+const socNominal = { id: 2 }
+const permissions = {} as PrisonerPermissions
+
+describe('buildOverviewInfoLinks', () => {
+  describe('Probation documents', () => {
+    it.each([true, false])(`User with permission can see 'Probation documents' link: %s`, permissionGranted => {
+      mockPermissions({ [ProbationDocumentsPermission.read]: permissionGranted })
+
+      const resp = buildOverviewInfoLinks(PrisonerMockDataA, pathfinderNominal, socNominal, permissions)
+
+      expect(resp.some(link => link.dataQA === 'probation-documents-info-link')).toEqual(permissionGranted)
+    })
+  })
+
+  describe('Incident summary', () => {
+    it('is always shown (caseload gating is handled by the sidebar)', () => {
+      mockPermissions({
+        [ProbationDocumentsPermission.read]: false,
+        [PathfinderPermission.read]: false,
+        [SOCPermission.read]: false,
+      })
+
+      const resp = buildOverviewInfoLinks(PrisonerMockDataA, pathfinderNominal, socNominal, permissions)
+
+      const link = resp.find(l => l.dataQA === 'incident-summary-info-link')
+      expect(link).toEqual({
+        text: 'Incident summary',
+        url: `${config.serviceUrls.incidentReporting}/prisoner/${PrisonerMockDataA.prisonerNumber}/incident-summary`,
+        dataQA: 'incident-summary-info-link',
+      })
+    })
+  })
+})

--- a/server/controllers/utils/overviewController/buildOverviewInfoLinks.ts
+++ b/server/controllers/utils/overviewController/buildOverviewInfoLinks.ts
@@ -41,5 +41,14 @@ export default function buildOverviewInfoLinks(
     })
   }
 
+  // Visibility is gated by the sidebar's caseload check (isInUsersCaseLoad), so no
+  // additional permission is required: any user who can see the prisoner can view the
+  // incident summary.
+  links.push({
+    text: 'Incident summary',
+    url: `${config.serviceUrls.incidentReporting}/prisoner/${prisonerData.prisonerNumber}/incident-summary`,
+    dataQA: 'incident-summary-info-link',
+  })
+
   return links
 }


### PR DESCRIPTION
## Summary
Adds an **Incident summary** link to the "More information" box on the prisoner profile overview page, linking to the prisoner's incident summary in the incident reporting service (`{INCIDENT_REPORTING_UI_URL}/prisoner/{prisonerNumber}/incident-summary`).

<img width="347" height="580" alt="Screenshot 2026-06-15 at 10 52 41" src="https://github.com/user-attachments/assets/aae48d50-4eb7-41a3-874e-1203b8f9387d" />


This is step 2 of linking the prisoner profile to the incident summary (the breadcrumb on the summary page is a separate PR in hmpps-incident-reporting under the same ticket - now in prod).

## Visibility
The link is shown whenever the prisoner is in the user's caseload — the "More information" sidebar is already gated by `isInUsersCaseLoad`, so the link is hidden for released or out-of-caseload prisoners. No additional permission is required, matching the incident summary page, which any signed-in user with the prisoner in caseload can view.

## Changes
- `buildOverviewInfoLinks.ts` — append the Incident summary link (uses existing `config.serviceUrls.incidentReporting` / `INCIDENT_REPORTING_UI_URL`).
- New unit test `buildOverviewInfoLinks.test.ts`.
- Cypress: page-object selector + assertion that the link shows for an in-caseload prisoner.
