### PR TITLE
Fix casenotes 400's by supporting legacy params / validating

### DIFF
--- a/server/controllers/caseNotesController.test.ts
+++ b/server/controllers/caseNotesController.test.ts
@@ -48,7 +48,7 @@ describe('Case Notes Controller', () => {
       params: { prisonerNumber: 'G6123VU' },
       query: {
         page: '0',
-        sort: 'dateCreated,ASC',
+        sort: 'createdAt,ASC',
         type: 'ACP',
         subType: 'ASSESSMENT',
         startDate: '01/01/2023',
@@ -109,7 +109,7 @@ describe('Case Notes Controller', () => {
         prisonerData: PrisonerMockDataA,
         queryParams: {
           page: 0,
-          sort: 'dateCreated,ASC',
+          sort: 'createdAt,ASC',
           type: 'ACP',
           subType: 'ASSESSMENT',
           startDate: '01/01/2023',
@@ -158,7 +158,7 @@ describe('Case Notes Controller', () => {
         prisonerData: PrisonerMockDataA,
         queryParams: {
           page: 0,
-          sort: 'dateCreated,ASC',
+          sort: 'createdAt,ASC',
           type: 'ACP',
           subType: 'ASSESSMENT',
           startDate: '01/01/2023',
@@ -232,6 +232,20 @@ describe('Case Notes Controller', () => {
         prisonerThumbnailImageUrl: '/api/prisoner/G6123VU/image?imageId=1413311&fullSizeImage=false',
       },
       errors: undefined,
+    })
+  })
+
+  describe('mapSortParam', () => {
+    it.each([
+      ['createdAt,ASC', 'createdAt,ASC'],
+      ['occurredAt,DESC', 'occurredAt,DESC'],
+      ['creationDateTime,ASC', 'createdAt,ASC'],
+      ['occurrenceDateTime,DESC', 'occurredAt,DESC'],
+      ['anythingElse,XYZ', 'createdAt,DESC'],
+      [undefined, 'createdAt,DESC'],
+    ])('maps %s to %s', (input, expected) => {
+      // eslint-disable-next-line dot-notation
+      expect(controller['mapSortParam'](input)).toEqual(expected)
     })
   })
 

--- a/server/controllers/caseNotesController.ts
+++ b/server/controllers/caseNotesController.ts
@@ -34,7 +34,7 @@ export default class CaseNotesController {
       const { clientToken, prisonerData, inmateDetail, alertSummaryData } = req.middleware
       const { user, prisonerPermissions } = res.locals
 
-      queryParams.sort = (req.query.sort as string) || 'createdAt,DESC'
+      queryParams.sort = this.mapSortParam(req.query.sort as string)
       if (req.query.page) queryParams.page = +req.query.page
       if (req.query.type) queryParams.type = req.query.type as string
       if (req.query.subType) queryParams.subType = req.query.subType as string
@@ -90,6 +90,25 @@ export default class CaseNotesController {
         addCaseNoteLinkUrl: `/prisoner/${prisonerData.prisonerNumber}/add-case-note`,
       })
     }
+  }
+
+  // Legacy support for sort param. Provides default if not recognised.
+  private mapSortParam(sort: string): string {
+    const oldSortFields: Record<string, string> = {
+      creationDateTime: 'createdAt',
+      occurrenceDateTime: 'occurredAt',
+    }
+    const sortFields = ['createdAt', 'occurredAt']
+    const defaultSort = 'createdAt,DESC'
+
+    if (!sort) return defaultSort
+
+    const [fieldInParam, direction] = sort.split(',')
+    const field = oldSortFields[fieldInParam] || fieldInParam
+
+    if (!sortFields.includes(field)) return defaultSort
+
+    return `${field},${direction}`
   }
 
   public displayAddCaseNote(): RequestHandler {


### PR DESCRIPTION
Case notes API had the sort fields renamed at some point, I think people are either linking or bookmarking using the old ones.

https://github.com/ministryofjustice/hmpps-prisoner-profile/blame/66777603168cd533de8b9b0fd94a40651c30ff27/server/services/caseNotesService.ts#L56

We weren't validating, hence:
```
POST /search/case-notes/{personIdentifier}

400 BAD_REQUEST Validation failure: Sort field invalid, please provide one of [occurredAt, createdAt]
```

So this PR does a little mapping and defaulting.