### PR TITLE
CDPS-1995: Word wrap govuk summary list key

### DIFF
--- a/assets/scss/overrides/_local.scss
+++ b/assets/scss/overrides/_local.scss
@@ -19,6 +19,8 @@ a.govuk-tabs__tab {
 
 .govuk-summary-list__key {
   width: 41%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .govuk-summary-list__value {


### PR DESCRIPTION
Fixed with word wrapping.
https://dsdmoj.atlassian.net/browse/CDPS-1995

<img width="1920" height="2286" alt="image" src="https://github.com/user-attachments/assets/19c48c08-41eb-406f-87f1-caf1e7b0e13e" />
