### PR TITLE
RR-2591 - Route and view changes to display Employability Skills from LWP

### DIFF
--- a/server/services/workAndSkillsPageService.test.ts
+++ b/server/services/workAndSkillsPageService.test.ts
@@ -62,7 +62,8 @@ describe('WorkAndSkillsService', () => {
   const personalLearningPlanService = new EducationAndWorkPlanApiPersonalLearningPlanService(
     null,
   ) as jest.Mocked<EducationAndWorkPlanApiPersonalLearningPlanService>
-  personalLearningPlanService.getPrisonerActionPlan = jest.fn().mockReturnValue(null)
+  personalLearningPlanService.getPrisonerActionPlan.mockResolvedValue(null)
+  personalLearningPlanService.getEmployabilitySkills.mockResolvedValue([])
 
   const workAndSkillsPageServiceConstruct = jest.fn(() => {
     return new WorkAndSkillsPageService(
@@ -124,6 +125,7 @@ describe('WorkAndSkillsService', () => {
 
   const expectedWorkAndSkills: WorkAndSkillsData = {
     learnerEmployabilitySkills: Result.fulfilled(learnerEmployabilitySkills),
+    employabilitySkills: Result.fulfilled([]),
     curiousGoals: Result.fulfilled(expectedCuriousGoals),
     workAndSkillsPrisonerName: ' ',
     offenderActivitiesHistory: expectedActivitiesHistory,

--- a/server/services/workAndSkillsPageService.ts
+++ b/server/services/workAndSkillsPageService.ts
@@ -9,16 +9,24 @@ import { properCaseName } from '../utils/utils'
 import { formatDate } from '../utils/dateHelpers'
 import { CuriousRestClientBuilder, RestClientBuilder } from '../data'
 import PersonalLearningPlanService from './personalLearningPlanService'
-import { PersonalLearningPlanActionPlan } from './interfaces/educationAndWorkPlanApiPersonalLearningPlanService/PersonalLearningPlanViewModels'
+import {
+  PersonalLearningPlanActionPlan,
+  PersonalLearningPlanEmployabilitySkill,
+} from './interfaces/educationAndWorkPlanApiPersonalLearningPlanService/PersonalLearningPlanViewModels'
 import CuriousGoals from './interfaces/workAndSkillsPageService/CuriousGoals'
 import toCuriousGoals from './mappers/curiousGoalsMapper'
 import LearnerEmployabilitySkills from '../data/interfaces/curiousApi/LearnerEmployabilitySkills'
 import CuriousApiClient from '../data/interfaces/curiousApi/curiousApiClient'
 import { Result } from '../utils/result/result'
 import { CuriousApiToken } from '../data/hmppsAuthClient'
+import config from '../config'
 
 export interface WorkAndSkillsData {
+  /**
+   * @deprecated - remove `learnerEmployabilitySkills` property when RR-2591 has been enabled in prod and the feature toggle `displayEmployabilitySkillsFromLwp` has been removed
+   */
   learnerEmployabilitySkills: Result<LearnerEmployabilitySkills>
+  employabilitySkills: Result<Array<PersonalLearningPlanEmployabilitySkill>>
   curiousGoals: Result<CuriousGoals>
   workAndSkillsPrisonerName: string
   offenderActivitiesHistory: ActivitiesHistoryData
@@ -56,12 +64,18 @@ export default class WorkAndSkillsPageService {
 
     const [
       learnerEmployabilitySkills,
+      employabilitySkills,
       curiousGoals,
       offenderActivitiesHistory,
       unacceptableAbsences,
       personalLearningPlanActionPlan,
     ] = await Promise.all([
-      this.getLearnerEmployabilitySkills(prisonerNumber, curiousApiClient, apiErrorCallback),
+      !config.featureToggles.displayEmployabilitySkillsFromLwp
+        ? this.getCuriousEmployabilitySkills(prisonerNumber, curiousApiClient, apiErrorCallback)
+        : null,
+      config.featureToggles.displayEmployabilitySkillsFromLwp
+        ? this.getLwpEmployabilitySkills(prisonerNumber, token, apiErrorCallback)
+        : null,
       this.getCuriousGoals(prisonerNumber, curiousApiClient, apiErrorCallback),
       this.getOffenderActivitiesHistory(prisonerNumber, prisonApiClient),
       this.getOffenderAttendanceHistoryStats(prisonerNumber, prisonApiClient),
@@ -70,6 +84,7 @@ export default class WorkAndSkillsPageService {
 
     return {
       learnerEmployabilitySkills,
+      employabilitySkills,
       curiousGoals,
       workAndSkillsPrisonerName,
       offenderActivitiesHistory,
@@ -131,12 +146,23 @@ export default class WorkAndSkillsPageService {
     return { activitiesHistory }
   }
 
-  private async getLearnerEmployabilitySkills(
+  /**
+   * @deprecated - Remove when RR-2591 has been enabled in prod and the feature toggle `displayEmployabilitySkillsFromLwp` has been removed
+   */
+  private async getCuriousEmployabilitySkills(
     prisonerNumber: string,
     curiousApiClient: CuriousApiClient,
     apiErrorCallback: (error: Error) => void,
   ): Promise<Result<LearnerEmployabilitySkills>> {
     return Result.wrap(curiousApiClient.getLearnerEmployabilitySkills(prisonerNumber), apiErrorCallback)
+  }
+
+  private async getLwpEmployabilitySkills(
+    prisonerNumber: string,
+    token: string,
+    apiErrorCallback: (error: Error) => void,
+  ) {
+    return Result.wrap(this.personalLearningPlanService.getEmployabilitySkills(prisonerNumber, token), apiErrorCallback)
   }
 
   private async getCuriousGoals(

--- a/server/views/pages/workAndSkills.njk
+++ b/server/views/pages/workAndSkills.njk
@@ -42,7 +42,11 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        {% include "../partials/workAndSkillsPage/employabilitySkills.njk" %}
+        {% if displayEmployabilitySkillsFromLwp() %}
+          {% include "../partials/workAndSkillsPage/employabilitySkills/lwpEmployabilitySkills.njk" %}
+        {% else %}
+          {% include "../partials/workAndSkillsPage/employabilitySkills/curiousEmployabilitySkills.njk" %}
+        {% endif %}
       </div>
     </div>
   {% endset %}

--- a/server/views/partials/workAndSkillsPage/employabilitySkills/curiousEmployabilitySkills.njk
+++ b/server/views/partials/workAndSkillsPage/employabilitySkills/curiousEmployabilitySkills.njk
@@ -1,4 +1,4 @@
-{% from "../../macros/summaryCardMacro.njk" import summaryCard %}
+{% from "../../../macros/summaryCardMacro.njk" import summaryCard %}
 {%- call summaryCard({title: "Employability skills", id: "employability-skills", classes: "hmpps-employability-card"}) -%}
     {% if learnerEmployabilitySkills.status === 'fulfilled'  %}
         {% set employabilitySkills = learnerEmployabilitySkills.value %}
@@ -32,7 +32,7 @@
             </div>
         {% endif %}
     {% else %}
-        {% include './curiousApiError.njk' %}
+        {% include '../curiousApiError.njk' %}
     {% endif %}
 
 {%- endcall -%}

--- a/server/views/partials/workAndSkillsPage/employabilitySkills/lwpEmployabilitySkills.njk
+++ b/server/views/partials/workAndSkillsPage/employabilitySkills/lwpEmployabilitySkills.njk
@@ -1,0 +1,28 @@
+{% from "../../../macros/summaryCardMacro.njk" import summaryCard %}
+{%- call summaryCard({title: "Employability skills", id: "employability-skills", classes: "hmpps-employability-card"}) -%}
+  {% if employabilitySkills.status === 'fulfilled'  %}
+    {% set employabilitySkills = employabilitySkills.value %}
+    <div>
+      <p>The careers information, advice and guidance (CIAG) and education teams record these skills.</p>
+      {% if employabilitySkills.length > 0 %}
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print" href="{{ config.serviceUrls.learningAndWorkProgress }}/plan/{{ prisonerNumber }}/view/employability-skills" data-qa="view-employability-skills">
+            View employability skills
+          </a>
+        </p>
+      {% else %}
+        <p class="govuk-body">
+          {{ workAndSkillsPrisonerName }} has no employability skills recorded yet.
+        </p>
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print" href="{{ config.serviceUrls.learningAndWorkProgress }}/plan/{{ prisonerNumber }}/view/employability-skills" data-qa="add-employability-skills">
+            Add employability skills
+          </a>
+        </p>
+      {% endif %}
+    </div>
+  {% else %}
+    {% include '../lwpApiError.njk' %}
+  {% endif %}
+
+{%- endcall -%}

--- a/server/views/partials/workAndSkillsPage/employabilitySkills/lwpEmployabilitySkills.test.ts
+++ b/server/views/partials/workAndSkillsPage/employabilitySkills/lwpEmployabilitySkills.test.ts
@@ -1,0 +1,83 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { parseISO } from 'date-fns'
+import { Result } from '../../../../utils/result/result'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+const templateParams = {
+  employabilitySkills: Result.fulfilled([]),
+}
+const template = 'lwpEmployabilitySkills.njk'
+
+describe('Work and Skills Page - Employability skills panel tests', () => {
+  it('should render given prisoner has employability skills', () => {
+    const params = {
+      ...templateParams,
+      employabilitySkills: Result.fulfilled([
+        {
+          employabilitySkillType: 'TEAMWORK',
+          employabilitySkillRating: 'QUITE_CONFIDENT',
+          evidence: 'Demonstrated in class',
+          sessionType: 'EDUCATION_REVIEW',
+          sessionTypeDescription: 'Maths class',
+          createdBy: 'asmith_gen',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: parseISO('2023-01-16T09:14:43.158Z'),
+          updatedBy: 'asmith_gen',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: parseISO('2023-09-23T14:43:02.094Z'),
+        },
+      ]),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=add-employability-skills]').length).toEqual(0)
+    expect($('[data-qa=view-employability-skills]').length).toEqual(1)
+    expect($('[data-qa=lwp-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should render given prisoner has no employability skills', () => {
+    const params = {
+      ...templateParams,
+      employabilitySkills: Result.fulfilled([]),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=add-employability-skills]').length).toEqual(1)
+    expect($('[data-qa=view-employability-skills]').length).toEqual(0)
+    expect($('[data-qa=lwp-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should render given employability skills promise is not resolved', () => {
+    const params = {
+      ...templateParams,
+      employabilitySkills: Result.rejected('Error retrieving LWP Employability Skills'),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=add-employability-skills]').length).toEqual(0)
+    expect($('[data-qa=view-employability-skills]').length).toEqual(0)
+    expect($('[data-qa=lwp-unavailable-message]').length).toEqual(1)
+  })
+})

--- a/server/views/partials/workAndSkillsPage/lwpApiError.njk
+++ b/server/views/partials/workAndSkillsPage/lwpApiError.njk
@@ -1,0 +1,7 @@
+{% from "../../macros/hmppsError.njk" import hmppsError %}
+{{ hmppsError({
+    type: 'service-unavailable',
+    dataQa: 'lwp-unavailable-message',
+    serviceName: 'Learning and work progress',
+    isAre: 'is'
+}) }}


### PR DESCRIPTION
PR to update the Work & Skills route to retrieve Employability Skills from LWP, and to update the nunjucks template based on the new designs for Employability Skills:

If the person has any Employability Skills:
<img width="708" height="206" alt="image" src="https://github.com/user-attachments/assets/583eac41-102e-4513-b798-679149d19f85" />


If the person has no Employability Skills:
<img width="732" height="196" alt="image" src="https://github.com/user-attachments/assets/9a2f2d98-898f-46d9-8c39-8ed35a47f264" />

(not shown in the images above, but the ticket specifies that "CIAG" should be spelt out as "The careers information, advice and guidance (CIAG)" )

Whether to retrieve and render Employability Skills from Curious or LWP is based on the feature toggle. The feature toggle is still disabled in all environments.
The next PR will update the cypress tests, and enable the toggle in `dev`