### PR TITLE
CDPS-2026: Handle latest x-ray body scan when sourced from NOMIS as opposed to DPS

### DIFF
--- a/integration_tests/e2e/overviewPage.cy.ts
+++ b/integration_tests/e2e/overviewPage.cy.ts
@@ -11,7 +11,11 @@ import {
 } from '../../server/data/localMockData/contactDetail'
 import { latestCalculationWithNomisSource } from '../../server/data/localMockData/latestCalculationMock'
 import { prisonerHasNeedsMock } from '../../server/data/localMockData/supportForAdditionalNeedsMock'
-import { mockScanResponse, mockScanSummaryResponse } from '../../server/data/localMockData/xRayBodyScansMock'
+import {
+  mockLegacyScanResponse,
+  mockScanResponse,
+  mockScanSummaryResponse,
+} from '../../server/data/localMockData/xRayBodyScansMock'
 import IndexPage from '../pages'
 
 const visitOverviewPage = ({ failOnStatusCode = true } = {}) => {
@@ -437,7 +441,7 @@ context('Overview Page', () => {
         overviewPage.xrayBodyScansCard.shouldShowNoScans()
       })
 
-      it('should show basic details of latest scan', () => {
+      it('should show basic details of latest scan if from DPS', () => {
         cy.task('stubXRayBodyListScans', {
           prisonerNumber: 'G6123VU',
           response: pageResponse([mockScanResponse('G6123VU', new Date(2026, 6, 20, 12))]),
@@ -445,6 +449,26 @@ context('Overview Page', () => {
         cy.visit('/prisoner/G6123VU')
         const overviewPage = Page.verifyOnPage(OverviewPage)
         overviewPage.xrayBodyScansCard.shouldShowLatestScan('20/07/2026', 'Item detected')
+      })
+
+      it('should show date of latest scan if from NOMIS', () => {
+        cy.task('stubXRayBodyListScans', {
+          prisonerNumber: 'G6123VU',
+          response: pageResponse([mockLegacyScanResponse('G6123VU', new Date(2026, 6, 20, 12))]),
+        })
+        cy.visit('/prisoner/G6123VU')
+        const overviewPage = Page.verifyOnPage(OverviewPage)
+        overviewPage.xrayBodyScansCard.shouldShowLatestScan('20/07/2026', null)
+      })
+
+      it('should not show date of latest scan if from NOMIS but no date was recorded', () => {
+        cy.task('stubXRayBodyListScans', {
+          prisonerNumber: 'G6123VU',
+          response: pageResponse([mockLegacyScanResponse('G6123VU', null)]),
+        })
+        cy.visit('/prisoner/G6123VU')
+        const overviewPage = Page.verifyOnPage(OverviewPage)
+        overviewPage.xrayBodyScansCard.shouldShowNoScans()
       })
 
       it('should link to scan history', () => {

--- a/integration_tests/mockApis/xRayBodyScansApi.ts
+++ b/integration_tests/mockApis/xRayBodyScansApi.ts
@@ -5,6 +5,7 @@ import type { PageResponse } from '../../server/data/interfaces/PageResponse'
 import { emptyPageResponse } from '../../server/data/localMockData/pageResponse'
 import type {
   ErrorResponse,
+  LegacyScanResponse,
   ListScansRequest,
   ScanResponse,
   ScanSummaryResponse,
@@ -31,7 +32,7 @@ export default {
     request,
   }: {
     prisonerNumber: string
-    response: PageResponse<ScanResponse> | ErrorResponse
+    response: PageResponse<ScanResponse | LegacyScanResponse> | ErrorResponse
     request?: ListScansRequest
   }): SuperAgentRequest {
     const queryParameters = dateFilters(request)
@@ -39,13 +40,20 @@ export default {
       'content' in response
         ? {
             ...response,
-            content: response.content.map(scan => ({
-              ...scan,
-              scanDate: formatISO(scan.scanDate, { representation: 'date' }),
-              mergedAt: scan.mergedAt ? formatISO(scan.mergedAt) : null,
-              createdAt: formatISO(scan.createdAt),
-              lastModifiedAt: formatISO(scan.lastModifiedAt),
-            })),
+            content: response.content.map(scan =>
+              scan.source === 'NOMIS'
+                ? {
+                    ...scan,
+                    scanDate: scan.scanDate ? formatISO(scan.scanDate, { representation: 'date' }) : null,
+                  }
+                : {
+                    ...scan,
+                    scanDate: formatISO(scan.scanDate, { representation: 'date' }),
+                    mergedAt: scan.mergedAt ? formatISO(scan.mergedAt) : null,
+                    createdAt: formatISO(scan.createdAt),
+                    lastModifiedAt: formatISO(scan.lastModifiedAt),
+                  },
+            ),
           }
         : response
     return stubFor({

--- a/integration_tests/pages/pageElements/xrayBodyScansCard.ts
+++ b/integration_tests/pages/pageElements/xrayBodyScansCard.ts
@@ -32,9 +32,13 @@ export default class XrayBodyScansCard {
     return this.container.find('p[data-qa="xray-body-scan-card__no-scans"]')
   }
 
-  shouldShowLatestScan(date: string, outcome: string): Cypress.Chainable<unknown> {
+  shouldShowLatestScan(date: string, outcome: string | null): Cypress.Chainable<unknown> {
     this.latestScanDate.should('contain.text', date)
-    this.latestScanOutcome.should('contain.text', outcome)
+    if (outcome === null) {
+      this.latestScanOutcome.should('not.exist')
+    } else {
+      this.latestScanOutcome.should('contain.text', outcome)
+    }
     return this.noScansNote.should('not.exist')
   }
 

--- a/server/controllers/interfaces/OverviewPageData.ts
+++ b/server/controllers/interfaces/OverviewPageData.ts
@@ -5,7 +5,7 @@ import { PersonalRelationshipsContactCount } from '../../data/interfaces/persona
 import AccountBalances from '../../data/interfaces/prisonApi/AccountBalances'
 import FullStatus from '../../data/interfaces/prisonApi/FullStatus'
 import StaffContacts, { YouthStaffContacts } from '../../data/interfaces/prisonApi/StaffContacts'
-import { ScanResponse } from '../../data/interfaces/xRayBodyScansApi'
+import { LegacyScanResponse, ScanResponse } from '../../data/interfaces/xRayBodyScansApi'
 import AdjudicationsOverviewSummary from '../../services/interfaces/adjudicationsService/AdjudicationsOverviewSummary'
 import IncentiveSummary from '../../services/interfaces/incentivesService/IncentiveSummary'
 import CourtAppearanceSummary from '../../services/interfaces/offencesService/CourtAppearanceSummary'
@@ -38,7 +38,7 @@ export default interface OverviewPageData {
   isYouthPrisoner: boolean
   prisonName: string
   xrayBodyScanSummary: Result<XrayBodyScanSummary> | null
-  xrayBodyScanLatest: Result<ScanResponse> | null
+  xrayBodyScanLatest: Result<ScanResponse | LegacyScanResponse> | null
   offencesOverview: {
     mainOffenceDescription: string
     fullStatus: FullStatus

--- a/server/controllers/overviewController.test.ts
+++ b/server/controllers/overviewController.test.ts
@@ -56,7 +56,11 @@ import { SupportForAdditionalNeedsApiClient } from '../data/interfaces/supportFo
 import { prisonerHasNeedsMock } from '../data/localMockData/supportForAdditionalNeedsMock'
 import type { XRayBodyScansApiClient } from '../data/interfaces/xRayBodyScansApi'
 import { xRayBodyScansApiClientMock } from '../../tests/mocks/xRayBodyScansApiClientMock'
-import { mockScanResponse, mockScanSummaryResponse } from '../data/localMockData/xRayBodyScansMock'
+import {
+  mockLegacyScanResponse,
+  mockScanResponse,
+  mockScanSummaryResponse,
+} from '../data/localMockData/xRayBodyScansMock'
 import ContactsService from '../services/contactsService'
 import { contactsServiceMock } from '../../tests/mocks/contactsServiceMock'
 import mockPermissions from '../../tests/mocks/mockPermissions'
@@ -954,7 +958,7 @@ describe('overviewController', () => {
       )
     })
 
-    it('should get latest scan from api', async () => {
+    it('should handle latest DPS scan from api', async () => {
       xRayBodyScansApiClient.listScans.mockResolvedValueOnce(pageResponse([mockScanResponse(offenderNo)]))
 
       await controller.displayOverview(req, resWithDpsDevRole)
@@ -965,6 +969,8 @@ describe('overviewController', () => {
           xrayBodyScanLatest: expect.objectContaining({
             status: 'fulfilled',
             value: expect.objectContaining({
+              source: 'DPS',
+              id: expect.any(String),
               prisonerNumber: offenderNo,
               prisonId: 'MDI',
               scanDate: expect.any(Date),
@@ -974,6 +980,28 @@ describe('overviewController', () => {
               outcomeDescription: 'Item detected',
               typeOfFind: 'INORGANIC',
               typeOfFindDescription: 'Inorganic',
+            }),
+          }),
+        }),
+      )
+    })
+
+    it('should handle latest NOMIS scan from api', async () => {
+      xRayBodyScansApiClient.listScans.mockResolvedValueOnce(pageResponse([mockLegacyScanResponse(offenderNo)]))
+
+      await controller.displayOverview(req, resWithDpsDevRole)
+
+      expect(resWithDpsDevRole.render).toHaveBeenCalledWith(
+        'pages/overviewPage',
+        expect.objectContaining({
+          xrayBodyScanLatest: expect.objectContaining({
+            status: 'fulfilled',
+            value: expect.objectContaining({
+              source: 'NOMIS',
+              id: expect.any(String),
+              prisonerNumber: offenderNo,
+              scanDate: expect.any(Date),
+              scanDetails: null,
             }),
           }),
         }),

--- a/server/controllers/utils/overviewController/mapXrayBodyScanData.ts
+++ b/server/controllers/utils/overviewController/mapXrayBodyScanData.ts
@@ -1,6 +1,6 @@
 import config from '../../../config'
 import type { PageResponse } from '../../../data/interfaces/PageResponse'
-import type { ScanResponse, ScanSummaryResponse } from '../../../data/interfaces/xRayBodyScansApi'
+import type { LegacyScanResponse, ScanResponse, ScanSummaryResponse } from '../../../data/interfaces/xRayBodyScansApi'
 
 /** Extended response from xray body scans api for overview page card */
 export interface XrayBodyScanSummary extends ScanSummaryResponse {
@@ -18,6 +18,8 @@ export function mapXrayBodyScanSummary(summaryResponse: ScanSummaryResponse): Xr
   }
 }
 
-export function mapLatestXrayBodyScan(listResponse: PageResponse<ScanResponse>): ScanResponse | null {
+export function mapLatestXrayBodyScan(
+  listResponse: PageResponse<ScanResponse | LegacyScanResponse>,
+): ScanResponse | LegacyScanResponse | null {
   return listResponse?.content?.[0] ?? null
 }

--- a/server/data/interfaces/xRayBodyScansApi/index.ts
+++ b/server/data/interfaces/xRayBodyScansApi/index.ts
@@ -6,7 +6,15 @@ export interface ListScansRequest extends PageRequest<'scanDate'> {
   toScanDate?: Date | undefined
 }
 
-export interface ScanResponse {
+export interface UnifiedScanResponse {
+  source: 'DPS' | 'NOMIS'
+  id: string
+  prisonerNumber: string
+  scanDate: Date | null
+}
+
+export interface ScanResponse extends UnifiedScanResponse {
+  source: 'DPS'
   id: string
   prisonerNumber: string
   prisonId: string
@@ -24,6 +32,14 @@ export interface ScanResponse {
   createdBy: string
   lastModifiedAt: Date
   lastModifiedBy: string
+}
+
+export interface LegacyScanResponse extends UnifiedScanResponse {
+  source: 'NOMIS'
+  id: string
+  prisonerNumber: string
+  scanDate: Date | null
+  scanDetails: string | null
 }
 
 export interface ScanSummaryRequest {
@@ -73,11 +89,14 @@ export interface ErrorResponse {
 
 export interface XRayBodyScansApiClient {
   /**
-   * Returns recorded x-ray body scans for the given prisoner.
+   * Returns x-ray body scans recorded in DPS or NOMIS for the given prisoner.
    * If the prisoner is not found, the list is empty.
    * Ensure the prisoner exists prior to use.
    */
-  listScans(prisonerNumber: string, request?: ListScansRequest): Promise<PageResponse<ScanResponse>>
+  listScans(
+    prisonerNumber: string,
+    request?: ListScansRequest,
+  ): Promise<PageResponse<ScanResponse | LegacyScanResponse>>
 
   /**
    * Returns a summary of x-ray body scans for the given prisoner for this calendar year.

--- a/server/data/localMockData/xRayBodyScansMock.ts
+++ b/server/data/localMockData/xRayBodyScansMock.ts
@@ -1,15 +1,16 @@
 import { startOfToday, startOfYear, subDays } from 'date-fns'
 import type {
   AlertResponse,
+  LegacyScanResponse,
   ScanResponse,
   ScanSummaryResponse,
   ScanSummaryResponseWithAlerts,
   ScanSummaryResponseWithoutAlerts,
 } from '../interfaces/xRayBodyScansApi'
 
-const sampleId = '019f94a7-17cd-746f-b1df-5d4848da42e1'
 const today = startOfToday()
 
+const sampleId = '019f94a7-17cd-746f-b1df-5d4848da42e1'
 export function mockScanResponse(
   prisonerNumber: string,
   scanDate: Date = subDays(today, 1),
@@ -17,6 +18,7 @@ export function mockScanResponse(
   createdBy = 'abc12a',
 ): ScanResponse {
   return {
+    source: 'DPS',
     id: sampleId,
     prisonerNumber,
     prisonId,
@@ -34,6 +36,21 @@ export function mockScanResponse(
     createdBy,
     lastModifiedAt: new Date(),
     lastModifiedBy: createdBy,
+  }
+}
+
+const sampleLegacyId = '715262'
+export function mockLegacyScanResponse(
+  prisonerNumber: string,
+  scanDate: Date | null = subDays(today, 10),
+  scanDetails: string | null = null,
+): LegacyScanResponse {
+  return {
+    source: 'NOMIS',
+    id: sampleLegacyId,
+    prisonerNumber,
+    scanDate,
+    scanDetails,
   }
 }
 

--- a/server/data/xRayBodyScansApiClient.ts
+++ b/server/data/xRayBodyScansApiClient.ts
@@ -3,6 +3,7 @@ import config from '../config'
 import { formatDateISO } from '../utils/dateHelpers'
 import type { PageResponse } from './interfaces/PageResponse'
 import type {
+  LegacyScanResponse,
   ListScansRequest,
   ScanResponse,
   ScanSummaryRequest,
@@ -20,6 +21,10 @@ interface RawScanResponse extends Omit<ScanResponse, 'scanDate' | 'mergedAt' | '
   lastModifiedAt: string
 }
 
+interface RawLegacyScanResponse extends Omit<LegacyScanResponse, 'scanDate'> {
+  scanDate: string | null
+}
+
 interface RawScanSummaryResponse extends Omit<ScanSummaryResponse, 'fromScanDate' | 'toScanDate'> {
   fromScanDate: string
   toScanDate: string
@@ -30,13 +35,16 @@ export default class XRayBodyScansApiRestClient extends RestClient implements XR
     super('X-ray Body Scans API', config.apis.xRayBodyScans, token, circuitBreaker)
   }
 
-  async listScans(prisonerNumber: string, request?: ListScansRequest): Promise<PageResponse<ScanResponse>> {
+  async listScans(
+    prisonerNumber: string,
+    request?: ListScansRequest,
+  ): Promise<PageResponse<ScanResponse | LegacyScanResponse>> {
     const query: object = {
       ...(request ?? {}),
       fromScanDate: request?.fromScanDate ? formatDateISO(request.fromScanDate) : undefined,
       toScanDate: request?.toScanDate ? formatDateISO(request.toScanDate) : undefined,
     }
-    const response = await this.get<PageResponse<RawScanResponse>>(
+    const response = await this.get<PageResponse<RawScanResponse | RawLegacyScanResponse>>(
       {
         path: `/prisoner/${encodeURIComponent(prisonerNumber)}/scan`,
         query,
@@ -45,14 +53,22 @@ export default class XRayBodyScansApiRestClient extends RestClient implements XR
     )
     return {
       ...response,
-      content: response.content.map(scan => ({
-        ...scan,
-        // using midday in order to avoid daylight saving switches:
-        scanDate: new Date(`${scan.scanDate}T12:00:00`),
-        mergedAt: scan.mergedAt ? new Date(scan.mergedAt) : null,
-        createdAt: new Date(scan.createdAt),
-        lastModifiedAt: new Date(scan.lastModifiedAt),
-      })),
+      content: response.content.map(scan =>
+        scan.source === 'NOMIS'
+          ? {
+              ...scan,
+              // using midday in order to avoid daylight saving switches:
+              scanDate: scan.scanDate ? new Date(`${scan.scanDate}T12:00:00`) : null,
+            }
+          : {
+              ...scan,
+              // using midday in order to avoid daylight saving switches:
+              scanDate: new Date(`${scan.scanDate}T12:00:00`),
+              mergedAt: scan.mergedAt ? new Date(scan.mergedAt) : null,
+              createdAt: new Date(scan.createdAt),
+              lastModifiedAt: new Date(scan.lastModifiedAt),
+            },
+      ),
     }
   }
 

--- a/server/views/partials/overviewPage/xrayBodyScansCard.njk
+++ b/server/views/partials/overviewPage/xrayBodyScansCard.njk
@@ -45,7 +45,7 @@
               text: unavailableApiErrorText
             }) }}
 
-          {% elseif xrayBodyScanLatest %}
+          {% elseif xrayBodyScanLatest and xrayBodyScanLatest.scanDate %}
 
             <p class="govuk-!-margin-bottom-1" data-qa="xray-body-scan-card__latest-date">
               {{ xrayBodyScanLatest.scanDate | formatDate('short') }}


### PR DESCRIPTION
Depends on [xrbs-api#63](https://github.com/ministryofjustice/hmpps-x-ray-body-scans-api/pull/63)

<img width="584" alt="Latest scan" src="https://github.com/user-attachments/assets/ba72eddd-7305-408b-87cd-ab2d403ac5c5" />
